### PR TITLE
docs: update readme to include supported node versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 
 ## Getting Started
 
+### Requirements
+- `node >= 16.x`
+
 ### Installation
 
 ```shell


### PR DESCRIPTION
## Description
As is tested in the CI, `inshellisense` currently will support node >= 16.x

Closes #24 & closes #14