### PR TITLE
feat: ask for desired shell if no args

### DIFF
--- a/src/commands/root.ts
+++ b/src/commands/root.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { initRender } from "../ui/ui-init.js";
 import { render } from "../ui/ui-root.js";
 import { executeShellCommandTTY, ExecuteShellCommandTTYResult } from "../runtime/utils.js";
 import { saveCommand, loadCommand } from "../utils/cache.js";
@@ -21,7 +22,7 @@ export const action = async (options: RootCommandOptions) => {
     process.exit(0);
   }
 
-  const shell = options.shell ?? "";
+  const shell = options.shell ?? (await initRender()) ?? "";
   if (!shells.map((s) => s.valueOf()).includes(shell)) {
     console.error(`Unsupported shell: '${shell}', supported shells: ${supportedShells}`);
     process.exit(1);

--- a/src/ui/ui-init.tsx
+++ b/src/ui/ui-init.tsx
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import React, { useState } from "react";
+import { Box, Text, render, useApp, useInput } from "ink";
+
+import { supportedShells } from "../utils/bindings.js";
+
+let uiResult = undefined;
+
+function UI() {
+  const { exit } = useApp();
+  const [selectionIdx, setSelectionIdx] = useState(0);
+  const [exited, setExited] = useState(false);
+
+  useInput(async (_, key) => {
+    if (key.upArrow) {
+      setSelectionIdx(Math.max(0, selectionIdx - 1));
+    } else if (key.downArrow) {
+      setSelectionIdx(Math.min(supportedShells.length - 1, selectionIdx + 1));
+    } else if (key.return) {
+      uiResult = supportedShells[selectionIdx];
+      setExited(true);
+      setTimeout(exit, 0);
+    }
+  });
+
+  return (
+    <>
+      {exited ? null : (
+        <Box flexDirection="column">
+          <Box>
+            <Text bold>Select your desired shell</Text>
+          </Box>
+          <Box flexDirection="column">
+            {supportedShells.map((shell, idx) => {
+              if (idx == selectionIdx) {
+                return (
+                  <Text color="cyan" underline key={idx}>
+                    {">"} {shell}
+                  </Text>
+                );
+              }
+              return (
+                <Text key={idx}>
+                  {"  "}
+                  {shell}
+                </Text>
+              );
+            })}
+          </Box>
+        </Box>
+      )}
+    </>
+  );
+}
+
+export const initRender = async (): Promise<string | undefined> => {
+  uiResult = undefined;
+  const { waitUntilExit } = render(<UI />);
+  await waitUntilExit();
+
+  return uiResult;
+};


### PR DESCRIPTION
The current error log when executed without arguments may be confusing to new users. This PR implements the ability to select a shell using the cursor when executed with no args.

Thank you for your consideration.