### PR TITLE
fix: make keys map closer to normal IDE intellisense

### DIFF
--- a/src/ui/input.tsx
+++ b/src/ui/input.tsx
@@ -15,12 +15,14 @@ export default function Input({
   prompt,
   activeSuggestion,
   tabCompletionDropSize,
+  setShowSuggestions,
 }: {
   value: string;
   setValue: (_: string) => void;
   prompt: string;
   activeSuggestion: Suggestion | undefined;
   tabCompletionDropSize: number;
+  setShowSuggestions: (_: boolean) => void;
 }) {
   const [cursorLocation, setCursorLocation] = useState(value.length);
   const [cursorBlink, setCursorBlink] = useState(true);
@@ -45,15 +47,18 @@ export default function Input({
       setValue([...value].slice(0, cursorLocation).join("") + [...value].slice(Math.min(value.length, cursorLocation + 1)).join(""));
     } else if (key.leftArrow) {
       setCursorLocation(Math.max(cursorLocation - 1, 0));
+      setShowSuggestions(false);
     } else if (key.rightArrow) {
       setCursorLocation(Math.min(cursorLocation + 1, value.length));
-    } else if (key.tab) {
+    } else if (key.tab || key.return) {
       if (activeSuggestion) {
         // TOOD: support insertValue
         const newValue = [...value].slice(0, cursorLocation - tabCompletionDropSize).join("") + activeSuggestion.name + " ";
         setValue(newValue);
         setCursorLocation(newValue.length);
       }
+    } else if (key.escape) {
+      setShowSuggestions(false);
     } else if (input) {
       setValue([...value].slice(0, cursorLocation).join("") + input + [...value].slice(cursorLocation).join(""));
       setCursorLocation(cursorLocation + input.length);

--- a/src/ui/suggestions.tsx
+++ b/src/ui/suggestions.tsx
@@ -65,10 +65,14 @@ export default function Suggestions({
   leftPadding,
   setActiveSuggestion,
   suggestions,
+  showSuggestions,
+  setShowSuggestions,
 }: {
   leftPadding: number;
   setActiveSuggestion: (_: Suggestion) => void;
   suggestions: Suggestion[];
+  showSuggestions: boolean;
+  setShowSuggestions: (_: boolean) => void;
 }) {
   const [activeSuggestionIndex, setActiveSuggestionIndex] = useState(0);
   const [windowWidth, setWindowWidth] = useState(500);
@@ -94,6 +98,10 @@ export default function Suggestions({
     }
   }, [suggestions]);
 
+  useEffect(() => {
+    setShowSuggestions(suggestions.length !== 0);
+  }, [suggestions, setShowSuggestions]);
+
   useInput((_, key) => {
     if (key.upArrow) {
       setActiveSuggestionIndex(Math.max(0, activeSuggestionIndex - 1));
@@ -110,23 +118,25 @@ export default function Suggestions({
     }
   }, []);
 
-  if (suggestions.length === 0) return <></>;
-
-  return (
-    <Box ref={measureRef}>
-      <Box paddingLeft={clampedLeftPadding}>
-        {swapDescription ? (
-          <>
-            <Description description={activeDescription} />
-            <SuggestionList suggestions={pagedSuggestions} activeSuggestionIdx={activePagedSuggestionIndex} />
-          </>
-        ) : (
-          <>
-            <SuggestionList suggestions={pagedSuggestions} activeSuggestionIdx={activePagedSuggestionIndex} />
-            <Description description={activeDescription} />
-          </>
-        )}
+  if (!showSuggestions) {
+    return <></>;
+  } else {
+    return (
+      <Box ref={measureRef}>
+        <Box paddingLeft={clampedLeftPadding}>
+          {swapDescription ? (
+            <>
+              <Description description={activeDescription} />
+              <SuggestionList suggestions={pagedSuggestions} activeSuggestionIdx={activePagedSuggestionIndex} />
+            </>
+          ) : (
+            <>
+              <SuggestionList suggestions={pagedSuggestions} activeSuggestionIdx={activePagedSuggestionIndex} />
+              <Description description={activeDescription} />
+            </>
+          )}
+        </Box>
       </Box>
-    </Box>
-  );
+    );
+  }
 }

--- a/src/ui/ui-root.tsx
+++ b/src/ui/ui-root.tsx
@@ -68,7 +68,14 @@ function UI({ startingCommand }: { startingCommand: string }) {
     <Box flexDirection="column" ref={measureRef}>
       <Box>
         <Text>
-          <Input value={command} setValue={setCommand} prompt={Prompt} activeSuggestion={activeSuggestion} tabCompletionDropSize={tabCompletionDropSize} />
+          <Input
+            value={command}
+            setValue={setCommand}
+            prompt={Prompt}
+            activeSuggestion={activeSuggestion}
+            tabCompletionDropSize={tabCompletionDropSize}
+            setShowSuggestions={setShowSuggestions}
+          />
         </Text>
       </Box>
       <Suggestions

--- a/src/ui/ui-root.tsx
+++ b/src/ui/ui-root.tsx
@@ -21,6 +21,7 @@ function UI({ startingCommand }: { startingCommand: string }) {
   const [tabCompletionDropSize, setTabCompletionDropSize] = useState(0);
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
   const [windowWidth, setWindowWidth] = useState(500);
+  const [showSuggestions, setShowSuggestions] = useState(false);
   const leftPadding = getLeftPadding(windowWidth, command);
 
   const measureRef = useCallback((node: DOMElement) => {
@@ -35,7 +36,7 @@ function UI({ startingCommand }: { startingCommand: string }) {
       uiResult = undefined;
       exit();
     }
-    if (key.return) {
+    if (key.return && !showSuggestions) {
       setIsExiting(true);
     }
   });
@@ -70,7 +71,13 @@ function UI({ startingCommand }: { startingCommand: string }) {
           <Input value={command} setValue={setCommand} prompt={Prompt} activeSuggestion={activeSuggestion} tabCompletionDropSize={tabCompletionDropSize} />
         </Text>
       </Box>
-      <Suggestions leftPadding={leftPadding} setActiveSuggestion={setActiveSuggestion} suggestions={suggestions} />
+      <Suggestions
+        leftPadding={leftPadding}
+        setActiveSuggestion={setActiveSuggestion}
+        suggestions={suggestions}
+        showSuggestions={showSuggestions}
+        setShowSuggestions={setShowSuggestions}
+      />
     </Box>
   );
 }


### PR DESCRIPTION
Addresses issue #59

## Changes

This pull request introduces the following changes:

1. Added a `showSuggestions` property to the `ui-root` component. This property controls the visibility of the suggestions dropdown in the UI.
2. Added a `setShowSuggestions` prop to the `Input` and `Suggestions` components. This prop is a function that can be used to programmatically control the visibility of the suggestions dropdown.
3. Added a `showSuggestions` prop to the `Suggestions` component, to better control when the autocompletion list should be shown.
4. Changed key actions. Now, the return key autocompletes terms when the suggestions dropdown is visible, and submits the command when the dropdown is invisible. Also stopped showing the dropdown when the left arrow key or esc key is pressed, to fit with IDE intellisense.

## Testing

Please ensure that the changes work as expected and that the suggestions dropdown can be shown and hidden by the intended keys.

## Reviewers

Please review this pull request and provide feedback.
