### PR TITLE
feat: support zsh alias

### DIFF
--- a/src/commands/root.ts
+++ b/src/commands/root.ts
@@ -5,9 +5,10 @@ import { initRender } from "../ui/ui-init.js";
 import { render } from "../ui/ui-root.js";
 import { executeShellCommandTTY, ExecuteShellCommandTTYResult } from "../runtime/utils.js";
 import { saveCommand, loadCommand } from "../utils/cache.js";
-import { supportedShells as shells } from "../utils/bindings.js";
+import { Shell, supportedShells as shells } from "../utils/bindings.js";
 import { inferShell } from "../utils/shell.js";
 import { Command } from "commander";
+import { aliaReplace } from "../utils/alias.js";
 
 export const supportedShells = shells.join(", ");
 
@@ -40,9 +41,10 @@ export const action = (program: Command) => async (options: RootCommandOptions) 
       result = { code: 0 };
       break;
     }
+    let aliasCommandToExecute = await aliaReplace(shell as Shell, commandToExecute)
 
-    commands.push(commandToExecute);
-    result = await executeShellCommandTTY(shell, commandToExecute);
+    commands.push(aliasCommandToExecute);
+    result = await executeShellCommandTTY(shell, aliasCommandToExecute);
     executed = true;
     startingCommand = undefined;
   }

--- a/src/utils/alias.ts
+++ b/src/utils/alias.ts
@@ -1,0 +1,47 @@
+import path from "node:path";
+import os from 'node:os'
+import fsAsync from "node:fs/promises";
+import { Shell } from "./bindings.js";
+export interface Alias {
+    from: string,
+    to: string
+}
+
+export const readAlias = async (shell: Shell): Promise<Alias[] | undefined> => {
+    switch (shell) {
+        case Shell.Zsh: {
+            const zshConfigPath = path.join(os.homedir(), ".zshrc");
+            const zshConfig = (await fsAsync.readFile(zshConfigPath)).toString();
+            return zshConfig
+                .split('\n')
+                .filter(line => line.startsWith('alias'))
+                .map(line => {
+                    //remove `alias ` and `"`
+                    const [from, to] = line.replace(/alias\s/, '')
+                        .replace(/\"/g, '')
+                        .split('=', 2);
+                    return { from, to };
+                });
+        }
+        //TODO more shell support
+    }
+}
+
+export const replaceCommand = async (shell: Shell) => {
+    const alias = await readAlias(shell);
+    return (command: string) => {
+        if (typeof alias === 'undefined')
+            return command;
+        for (const aliaPair of alias) {
+            if (aliaPair.from === command)
+                return aliaPair.to
+        }
+        return command;
+    }
+
+}
+
+export const aliaReplace = async (shell: Shell, command: string) => {
+    const replace = await replaceCommand(shell);
+    return replace(command);
+}


### PR DESCRIPTION
I'm trying to make alias work. I just write a zsh alias version for  inshellisense. If it work well, i'll support other shell. : )

In zsh config :
```
# ~/.zshrc

#alias
alias t="echo hello"
```

and in the inshellisense :
![image](https://github.com/microsoft/inshellisense/assets/36598604/220dc282-1d49-44b4-81d1-7f41d4959d25)
