### PR TITLE
fix: search for the npm directory before binding the shortcut key (fix #50)

### DIFF
--- a/shell/key-bindings-powershell.ps1
+++ b/shell/key-bindings-powershell.ps1
@@ -12,7 +12,9 @@ Set-PSReadLineKeyHandler -Chord 'Ctrl+a' -ScriptBlock {
     [Microsoft.PowerShell.PSConsoleReadLine]::KillLine()
     [Microsoft.PowerShell.PSConsoleReadLine]::AcceptLine()
 
-    $inshellisense = "$env:USERPROFILE\AppData\Roaming\npm\node_modules\@microsoft\inshellisense\build\index.js"
+    $npmPrefix = npm config get prefix
+    $inshellisense = Join-Path $npmPrefix "\node_modules\@microsoft\inshellisense\build\index.js"
+    
     if ($command) {
         Start-Process -NoNewWindow -Wait "node" "$inshellisense -c $command -s powershell"
     }

--- a/shell/key-bindings-pwsh.ps1
+++ b/shell/key-bindings-pwsh.ps1
@@ -11,7 +11,9 @@ Set-PSReadLineKeyHandler -Chord 'Ctrl+a' -ScriptBlock {
     [Microsoft.PowerShell.PSConsoleReadLine]::BeginningOfLine()
     [Microsoft.PowerShell.PSConsoleReadLine]::KillLine()
 
-    $inshellisense = "$env:USERPROFILE\AppData\Roaming\npm\node_modules\@microsoft\inshellisense\build\index.js"
+    $npmPrefix = npm config get prefix
+    $inshellisense = Join-Path $npmPrefix "\node_modules\@microsoft\inshellisense\build\index.js"
+    
     if ($command) {
         Start-Process -NoNewWindow -Wait "node" "$inshellisense -c $command -s pwsh"
     }


### PR DESCRIPTION
fix [Cannot find module when press ctrl+a to tigger completion](https://github.com/microsoft/inshellisense/issues/50)