### PR TITLE
fix: shell inference when ENV:SHELL isn't set & add back option for user to supply shell

### DIFF
--- a/src/commands/root.ts
+++ b/src/commands/root.ts
@@ -9,10 +9,14 @@ import { Command } from "commander";
 
 export const supportedShells = shells.join(", ");
 
-export const action = (program: Command) => async () => {
+type RootCommandOptions = {
+  shell: Shell | undefined;
+};
+
+export const action = (program: Command) => async (options: RootCommandOptions) => {
   await loadConfig(program);
 
-  const shell = (await inferShell()) as unknown as Shell | undefined;
+  const shell = options.shell ?? ((await inferShell()) as unknown as Shell | undefined);
   if (shell == null) {
     program.error(`Unable to identify shell, use the -s/--shell option to provide your shell`, { exitCode: 1 });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { Command } from "commander";
 
 import bind from "./commands/bind.js";
 import uninstall from "./commands/uninstall.js";
-import { action } from "./commands/root.js";
+import { action, supportedShells } from "./commands/root.js";
 import { getVersion } from "./utils/version.js";
 
 const program = new Command();
@@ -19,6 +19,7 @@ program
   .description("IDE style command line auto complete")
   .version(await getVersion(), "-v, --version", "output the current version")
   .action(action(program))
+  .option("-s, --shell <shell>", `shell to use for command execution, supported shells: ${supportedShells}`)
   .showHelpAfterError("(add --help for additional information)");
 
 program.addCommand(bind);

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -10,7 +10,9 @@ import fs from "node:fs";
 
 export const inferShell = async () => {
   try {
-    return path.parse(process.env.SHELL ?? "").name;
+    const name = path.parse(process.env.SHELL ?? "").name;
+    const shellName = supportedShells.find((shell) => name.includes(shell));
+    if (shellName) return shellName;
   } catch {
     /* empty */
   }


### PR DESCRIPTION
## Description
Adds the above described fixes after changes from #91

## Testing
- [x] tested inference against: git-bash, pwsh, powershell, bash (wsl), fish (wsl), zsh (wsl)