### PR TITLE
feat: restore argument descriptions & tweak keystroke management

### DIFF
--- a/src/isterm/pty.ts
+++ b/src/isterm/pty.ts
@@ -88,6 +88,10 @@ export class ISTerm implements IPty {
     return true;
   }
 
+  noop() {
+    this.#ptyEmitter.emit(ISTermOnDataEvent, "");
+  }
+
   resize(columns: number, rows: number) {
     this.cols = columns;
     this.rows = rows;

--- a/src/ui/ui-root.ts
+++ b/src/ui/ui-root.ts
@@ -91,7 +91,7 @@ export const render = async (shell: Shell) => {
   process.stdin.on("data", (d: Buffer) => {
     const suggestionResult = suggestionManager.update(d);
     if (previousSuggestionsColumns > 0 && suggestionResult == "handled") {
-      term.write("\u001B[m");
+      term.noop();
     } else if (!suggestionResult) {
       term.write(inputModifier(d));
     }

--- a/src/utils/ansi.ts
+++ b/src/utils/ansi.ts
@@ -4,6 +4,7 @@
 const CSI = "\u001B[";
 const OSC = "\u001B]";
 const BEL = "\u0007";
+const SS3 = "\u001BO";
 
 export const IsTermOscPs = 6973;
 const IS_OSC = OSC + IsTermOscPs + ";";
@@ -33,7 +34,7 @@ export const eraseLinesBelow = (count = 1) => {
   return [...Array(count).keys()].map(() => cursorNextLine + eraseLine).join("");
 };
 
-export const parseKeystroke = (b: Buffer): "up" | "down" | "tab" | "ctrl-space" | undefined => {
+export const parseKeystroke = (b: Buffer): "up" | "down" | "tab" | "right-arrow" | undefined => {
   let s: string;
   if (b[0] > 127 && b[1] === undefined) {
     b[0] -= 128;
@@ -42,13 +43,13 @@ export const parseKeystroke = (b: Buffer): "up" | "down" | "tab" | "ctrl-space" 
     s = String(b);
   }
 
-  if (s == CSI + "A") {
+  if (s == CSI + "A" || s == SS3 + "A") {
     return "up";
-  } else if (s == CSI + "B") {
+  } else if (s == CSI + "B" || s == SS3 + "B") {
     return "down";
   } else if (s == "\t") {
     return "tab";
-  } else if (s == "\u0000") {
-    return "ctrl-space";
+  } else if (s == CSI + "D" || s == SS3 + "D" || s == CSI + "d" || s == SS3 + "d") {
+    return "right-arrow";
   }
 };


### PR DESCRIPTION
## Description
Does the following:
- Adds back suggestion descriptions 
![image](https://github.com/microsoft/inshellisense/assets/35637443/24cc127c-6a05-4ef5-ba29-d297c5bb83ee)
- Adds in argument descriptions
![image](https://github.com/microsoft/inshellisense/assets/35637443/23b4e142-1909-45fc-a853-3c4953b652ac)
- Fixes issue with noops for rendering changes on key navigation
- changes `^space` to `>` for sending tab when suggestions are active.
