### PR TITLE
 docs: fix typo in Node-gyp Package Repository Link in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ### Requirements
 
 - `node >= 16.x`
-- node-gyp dependencies installed for your platform (see [node-gyp](https://github.com/microsoft/node-gyp) for more details)
+- node-gyp dependencies installed for your platform (see [node-gyp](https://github.com/nodejs/node-gyp) for more details)
 
 ### Installation
 


### PR DESCRIPTION
This pull request addresses a minor typo in the README.md file where  the Node-gyp package link leads to a 404 error page, and this fix updates it to the correct repository URL. 

here's screenshot of the page that the current link redirect too : 
![image](https://github.com/microsoft/inshellisense/assets/59267562/450f7a2c-ca26-48a0-aa26-42b740e71403)

