### PR TITLE
feat: ability to check if the terminal in an `inshellisense` session

### DIFF
--- a/src/commands/root.ts
+++ b/src/commands/root.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { render } from "../ui/ui-root.js";
+import { render, renderConfirmation } from "../ui/ui-root.js";
 import { Shell, supportedShells as shells, setupZshDotfiles } from "../utils/shell.js";
 import { inferShell } from "../utils/shell.js";
 import { loadConfig } from "../utils/config.js";
@@ -13,9 +13,16 @@ export const supportedShells = shells.join(", ");
 type RootCommandOptions = {
   shell: Shell | undefined;
   verbose: boolean | undefined;
+  check: boolean | undefined;
 };
 
 export const action = (program: Command) => async (options: RootCommandOptions) => {
+  const inISTerm = process.env.ISTERM === "1";
+  if (options.check || inISTerm) {
+    process.stdout.write(renderConfirmation(inISTerm));
+    return;
+  }
+
   if (options.verbose) await log.enable();
 
   await loadConfig(program);

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ program
   .version(await getVersion(), "-v, --version", "output the current version")
   .action(action(program))
   .option("-s, --shell <shell>", `shell to use for command execution, supported shells: ${supportedShells}`)
+  .option("-c, --check", `check if shell is in an inshellisense session`)
   .option("-V, --verbose", `enable verbose logging`)
   .showHelpAfterError("(add --help for additional information)");
 

--- a/src/isterm/pty.ts
+++ b/src/isterm/pty.ts
@@ -236,14 +236,18 @@ const convertToPtyTarget = async (shell: Shell) => {
 };
 
 const convertToPtyEnv = (shell: Shell) => {
+  const env = {
+    ...process.env,
+    ISTERM: "1",
+  };
   switch (shell) {
     case Shell.Cmd: {
       const prompt = process.env.PROMPT ? process.env.PROMPT : "$P$G";
-      return { ...process.env, PROMPT: `${IstermPromptStart}${prompt}${IstermPromptEnd}` };
+      return { ...env, PROMPT: `${IstermPromptStart}${prompt}${IstermPromptEnd}` };
     }
     case Shell.Zsh: {
-      return { ...process.env, ZDOTDIR: zdotdir, USER_ZDOTDIR: userZdotdir };
+      return { ...env, ZDOTDIR: zdotdir, USER_ZDOTDIR: userZdotdir };
     }
   }
-  return process.env;
+  return env;
 };

--- a/src/ui/ui-root.ts
+++ b/src/ui/ui-root.ts
@@ -1,13 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import ansi from "ansi-escapes";
+import chalk from "chalk";
+
 import { inputModifier } from "./input.js";
 import log from "../utils/log.js";
 import { Shell } from "../utils/shell.js";
 import isterm from "../isterm/index.js";
 import { eraseLinesBelow } from "../utils/ansi.js";
-import ansi from "ansi-escapes";
 import { SuggestionManager, MAX_LINES } from "./suggestionManager.js";
+
+export const renderConfirmation = (live: boolean): string => {
+  const statusMessage = live ? chalk.green("live") : chalk.red("not found");
+  return `inshellisense session [${statusMessage}]\n`;
+};
 
 export const render = async (shell: Shell) => {
   const term = await isterm.spawn({ shell, rows: process.stdout.rows, cols: process.stdout.columns });


### PR DESCRIPTION
The user can check if they are in an `inshellisense` session via `is -c` and it prevents running nested sessions.