### PR TITLE
fix: lock autocomplete version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1-rc.6",
       "license": "MIT",
       "dependencies": {
-        "@withfig/autocomplete": "^2.633.0",
+        "@withfig/autocomplete": "2.648.2",
         "ajv": "^8.12.0",
         "ansi-escapes": "^6.2.0",
         "ansi-styles": "^6.2.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/microsoft/inshellisense#readme",
   "dependencies": {
-    "@withfig/autocomplete": "^2.633.0",
+    "@withfig/autocomplete": "2.648.2",
     "ajv": "^8.12.0",
     "ansi-escapes": "^6.2.0",
     "ansi-styles": "^6.2.1",


### PR DESCRIPTION
#148

I currently believe that we need to lock the autocomplete version until loadspecs is compatible.