### PR TITLE
docs: update to reflect node versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ### Requirements
 
-- `node >= 16.x`
+- `20.x >= node >= 16.x`
 - node-gyp dependencies installed for your platform (see [node-gyp](https://github.com/nodejs/node-gyp) for more details)
 
 ### Installation

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.1-rc.7",
   "description": "IDE style command line auto complete",
   "type": "module",
+  "engines": {
+    "node" : ">=16.6.0 <21.0.0"
+  },
   "bin": {
     "inshellisense": "./build/index.js",
     "is": "./build/index.js"


### PR DESCRIPTION
`node-pty` only currently supports node 18, but will still work for now with Node 16/Node 20. Including node versions as part of the readme.  Closes #144 