### PR TITLE
fix: support new version autocomplete

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1-rc.7",
       "license": "MIT",
       "dependencies": {
-        "@withfig/autocomplete": "2.648.2",
+        "@withfig/autocomplete": "2.651.0",
         "ajv": "^8.12.0",
         "ansi-escapes": "^6.2.0",
         "ansi-styles": "^6.2.1",
@@ -42,6 +42,9 @@
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.2",
         "typescript": "^5.2.2"
+      },
+      "engines": {
+        "node": ">=16.6.0 <21.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2089,9 +2092,9 @@
       }
     },
     "node_modules/@withfig/autocomplete": {
-      "version": "2.648.2",
-      "resolved": "https://registry.npmjs.org/@withfig/autocomplete/-/autocomplete-2.648.2.tgz",
-      "integrity": "sha512-Dw6Irj1YoWEq92zCPRLNDMA4voKjna7jr10DuHHvnrFRbt4xOiYVbBZM+mPCkRMTerUOjrSOcPGQM4j3sA/fyA==",
+      "version": "2.651.0",
+      "resolved": "https://registry.npmjs.org/@withfig/autocomplete/-/autocomplete-2.651.0.tgz",
+      "integrity": "sha512-Qw9cRf1rqMyervbtU7SU2XZcIBCJW4OmSP0ykgnzw5tP0FmZZhnyZKl8guzoDVvKfdBDBYwecqnLbBIF0sEruQ==",
       "dependencies": {
         "@fig/autocomplete-generators": "^2.4.0",
         "@fig/autocomplete-helpers": "^1.0.7",
@@ -9521,9 +9524,9 @@
       }
     },
     "@withfig/autocomplete": {
-      "version": "2.648.2",
-      "resolved": "https://registry.npmjs.org/@withfig/autocomplete/-/autocomplete-2.648.2.tgz",
-      "integrity": "sha512-Dw6Irj1YoWEq92zCPRLNDMA4voKjna7jr10DuHHvnrFRbt4xOiYVbBZM+mPCkRMTerUOjrSOcPGQM4j3sA/fyA==",
+      "version": "2.651.0",
+      "resolved": "https://registry.npmjs.org/@withfig/autocomplete/-/autocomplete-2.651.0.tgz",
+      "integrity": "sha512-Qw9cRf1rqMyervbtU7SU2XZcIBCJW4OmSP0ykgnzw5tP0FmZZhnyZKl8guzoDVvKfdBDBYwecqnLbBIF0sEruQ==",
       "requires": {
         "@fig/autocomplete-generators": "^2.4.0",
         "@fig/autocomplete-helpers": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/microsoft/inshellisense#readme",
   "dependencies": {
-    "@withfig/autocomplete": "2.648.2",
+    "@withfig/autocomplete": "2.651.0",
     "ajv": "^8.12.0",
     "ansi-escapes": "^6.2.0",
     "ansi-styles": "^6.2.1",

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -19,6 +19,9 @@ const specSet: any = {};
   let activeSet = specSet;
   const specRoutes = s.split("/");
   specRoutes.forEach((route, idx) => {
+    if (typeof activeSet !== 'object') {
+      return;
+    }
     if (idx === specRoutes.length - 1) {
       const prefix = versionedSpeclist.includes(s) ? "/index.js" : `.js`;
       activeSet[route] = `@withfig/autocomplete/build/${s}${prefix}`;


### PR DESCRIPTION
I submitted this PR, but there are a few points that I'm uncertain about and need to discuss:

1. Do we need to lock the version of `@withfig/autocomplete` or revert it back to the previous ^? We previously locked the version because the new updates from fig caused user startup errors. I locked the version as a temporary solution. Since I have now fixed the error caused by the loading standards, I upgraded the package version. If we decide to revert to ^, I will need to make another change. The advantage of locking the version is that we don't have to worry about fig updates causing unexpected errors in our implementation, but the downside is that we need to continually update it.
<img width="993" alt="image" src="https://github.com/microsoft/inshellisense/assets/9245110/117151da-bc28-45dc-9eb2-357880c69cc2">

2. The reason for the error when installing new versions of `@withfig/autocomplete`, such as v2.651.0, is that it provided specifications with certain information that led to errors. Firstly, I think this is unreasonable, and I understand it to be an issue with the Fig autocomplete package. However, for the inshellisense project, I believe we can improve robustness to prevent the unreasonableness of a single specification from causing errors in the overall load.
<img width="627" alt="image" src="https://github.com/microsoft/inshellisense/assets/9245110/fa57c90d-18b7-4c70-be57-42212647b9f3">
<img width="905" alt="image" src="https://github.com/microsoft/inshellisense/assets/9245110/8707533c-26fc-4f51-8bec-41d10743397a">

