### PR TITLE
fix: reset the selected completion index to 0 to prevent the selected…

### DIFF
--- a/src/ui/suggestionManager.ts
+++ b/src/ui/suggestionManager.ts
@@ -87,7 +87,10 @@ export class SuggestionManager {
 
   async render(remainingLines: number): Promise<SuggestionsSequence> {
     await this._loadSuggestions();
-    if (!this.#suggestBlob) return { data: "", rows: 0 };
+    if (!this.#suggestBlob) {
+      this.#activeSuggestionIdx = 0;
+      return {data: "", rows: 0};
+    }
     const { suggestions, argumentDescription } = this.#suggestBlob;
 
     const page = Math.min(Math.floor(this.#activeSuggestionIdx / maxSuggestions) + 1, Math.floor(suggestions.length / maxSuggestions) + 1);

--- a/src/ui/suggestionManager.ts
+++ b/src/ui/suggestionManager.ts
@@ -89,7 +89,7 @@ export class SuggestionManager {
     await this._loadSuggestions();
     if (!this.#suggestBlob) {
       this.#activeSuggestionIdx = 0;
-      return {data: "", rows: 0};
+      return { data: "", rows: 0 };
     }
     const { suggestions, argumentDescription } = this.#suggestBlob;
 


### PR DESCRIPTION
I found that the default selected index for completion needs to be reset to avoid the default selected index still being the previously selected one when the completion is displayed.


Please help to review this. @cpendery 