### PR TITLE
fix: subCommands find problem

### DIFF
--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -118,8 +118,7 @@ const genSubcommand = async (command: string, parentCommand: Fig.Subcommand): Pr
   const subcommandIdx = parentCommand.subcommands.findIndex((s) => Array.isArray(s.name) ? s.name.includes(command) : s.name === command);
   
   if (subcommandIdx === -1) return;
-  const subcommand = parentCommand.subcommands?.at(subcommandIdx);
-  if (subcommand == null) return;
+  const subcommand = parentCommand.subcommands[subcommandIdx];
 
   // this pulls in the spec from the load spec and overwrites the subcommand in the parent with the loaded spec.
   // then it returns the subcommand and clears the loadSpec field so that it doesn't get called again

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -114,9 +114,9 @@ const executeShellCommand = buildExecuteShellCommand(5000);
 
 const genSubcommand = async (command: string, parentCommand: Fig.Subcommand): Promise<Fig.Subcommand | undefined> => {
   if (!parentCommand.subcommands || parentCommand.subcommands.length === 0) return;
-  
-  const subcommandIdx = parentCommand.subcommands.findIndex((s) => Array.isArray(s.name) ? s.name.includes(command) : s.name === command);
-  
+
+  const subcommandIdx = parentCommand.subcommands.findIndex((s) => (Array.isArray(s.name) ? s.name.includes(command) : s.name === command));
+
   if (subcommandIdx === -1) return;
   const subcommand = parentCommand.subcommands[subcommandIdx];
 

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -113,8 +113,19 @@ const getSubcommand = (spec?: Fig.Spec): Fig.Subcommand | undefined => {
 const executeShellCommand = buildExecuteShellCommand(5000);
 
 const genSubcommand = async (command: string, parentCommand: Fig.Subcommand): Promise<Fig.Subcommand | undefined> => {
-  const subcommandIdx = parentCommand.subcommands?.findIndex((s) => s.name === command);
-  if (subcommandIdx == null) return;
+  if (!parentCommand.subcommands || parentCommand.subcommands.length === 0) return;
+  
+  const subcommandIdx = parentCommand.subcommands?.findIndex((s) => {
+    // subCommand.name can be a string or an array of strings
+    if (Array.isArray(s.name)) {
+      // if it's an array, we check if the command is included in the array
+      return s.name.includes(command);
+    } else {
+      return s.name === command;
+    }
+  });
+  
+  if (subcommandIdx === -1) return;
   const subcommand = parentCommand.subcommands?.at(subcommandIdx);
   if (subcommand == null) return;
 

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -115,15 +115,7 @@ const executeShellCommand = buildExecuteShellCommand(5000);
 const genSubcommand = async (command: string, parentCommand: Fig.Subcommand): Promise<Fig.Subcommand | undefined> => {
   if (!parentCommand.subcommands || parentCommand.subcommands.length === 0) return;
   
-  const subcommandIdx = parentCommand.subcommands?.findIndex((s) => {
-    // subCommand.name can be a string or an array of strings
-    if (Array.isArray(s.name)) {
-      // if it's an array, we check if the command is included in the array
-      return s.name.includes(command);
-    } else {
-      return s.name === command;
-    }
-  });
+  const subcommandIdx = parentCommand.subcommands.findIndex((s) => Array.isArray(s.name) ? s.name.includes(command) : s.name === command);
   
   if (subcommandIdx === -1) return;
   const subcommand = parentCommand.subcommands?.at(subcommandIdx);


### PR DESCRIPTION
First of all, thanks for this awesome project, which has given me a lot of inspiration in the areas of terminal experience and smart completion. I have recently been trying to integrate it with Xterm.js. However, I encountered some issues while using it and reading the code.

## What is the problem ?
When I type `npm run`, the terminal autocomplete returns the incorrect result "--registry", instead of the scripts in package.json or other run parameters. 

![image](https://github.com/microsoft/inshellisense/assets/12879047/0ae329ba-c819-4893-911a-1e43b68cae6d)

This behavior is somewhat strange, so I delved into the source code to look for the issue.

After spending some time debugging, the problem was finally located in the `genSubCommand` method of the `runtime.ts` file.

![image](https://github.com/microsoft/inshellisense/assets/12879047/83383446-b2d1-4c92-bc8f-5445dc5ed98b)


Here, we can see that when typing `npm run`, function `genSubCommand` attempting to find `s.name === 'run' `within ·parentCommand.subcommands· is unsuccessful, returning `subcommandIdx` is `-1`. 

However, the judgment logic in the code is `SubCommand == null`, which obviously does not apply when `subCommand` is -1. As a result, it proceeds to `parentCommand.subcommands.at(-1)`, effectively retrieving the last item in the `subcommands` list (the 69th item). Therefore, the output becomes `--registry` instead of the correct result.

<img width="565" alt="image" src="https://github.com/microsoft/inshellisense/assets/12879047/5bc69df2-040a-4c2c-ac3c-62442f67c062">

## How to Fix 

<img width="558" alt="image" src="https://github.com/microsoft/inshellisense/assets/12879047/e149b092-1c5b-4a2e-b3b2-3a3a114daeec">

By inspecting the contents of `parentCommand.subcommands` through the Debugger, it can be observed that the `name` of a `subCommand` might be an array of strings. And the type of subCommand also prove this.

<img width="473" alt="image" src="https://github.com/microsoft/inshellisense/assets/12879047/a4e9ec35-6b2f-46dd-b877-825e45358db1">

Therefore, we need to fix the find matching logic for `subCommands` to handle both arrays and strings during the match. 
``` typescript
  const subcommandIdx = parentCommand.subcommands?.findIndex((s) => {
    // subCommand.name can be a string or an array of strings
    if (Array.isArray(s.name)) {
      // if it's an array, we check if the command is included in the array
      return s.name.includes(command);
    } else {
      return s.name === command;
    }
  });
```
Additionally, we also need to optimize the verification logic before and after the find match to handle exceptional cases.
``` typescript
  if (!parentCommand.subcommands || parentCommand.subcommands.length === 0) return;
  // ... find logic 
  if (subcommandIdx === -1) return;
```

## After fix
After fix, `npm run` looks great ! 
![image](https://github.com/microsoft/inshellisense/assets/12879047/f2cfc644-b31b-48b0-b924-3ecaa29b5603)
