### PR TITLE
fix: stale suggestion appearing after command execution

### DIFF
--- a/src/ui/suggestionManager.ts
+++ b/src/ui/suggestionManager.ts
@@ -87,6 +87,11 @@ export class SuggestionManager {
     );
   }
 
+  validate(suggestion: SuggestionsSequence): SuggestionsSequence {
+    const commandText = this.#term.getCommandState().commandText;
+    return !commandText ? { data: "", rows: 0 } : suggestion;
+  }
+
   async render(remainingLines: number): Promise<SuggestionsSequence> {
     await this._loadSuggestions();
     if (!this.#suggestBlob) {

--- a/src/ui/ui-root.ts
+++ b/src/ui/ui-root.ts
@@ -57,8 +57,9 @@ export const render = async (shell: Shell, underTest: boolean) => {
       writeOutput(data);
     }
 
-    setImmediate(async () => {
-      const suggestion = await suggestionManager.render(term.getCursorState().remainingLines);
+    process.nextTick(async () => {
+      // validate result to prevent stale suggestion being provided
+      const suggestion = suggestionManager.validate(await suggestionManager.render(term.getCursorState().remainingLines));
       const commandState = term.getCommandState();
 
       if (suggestion.data != "" && commandState.cursorTerminated && !commandState.hasOutput) {


### PR DESCRIPTION
When executing a command with live suggestions `git `, the suggestions were appearing after command execution due to a race condition. This fixes that by applying a manual check after the promise is resolved that the suggestion should still be provided