### PR TITLE
fix: zsh integration to work with powerlevel10k / themes

### DIFF
--- a/shell/shellIntegration-rc.zsh
+++ b/shell/shellIntegration-rc.zsh
@@ -48,6 +48,9 @@ __is_update_prompt() {
 }
 
 __is_precmd() {
+	if [[ $PS1 != *"$(__is_prompt_start)"* ]]; then
+		__is_update_prompt
+	fi
 	__is_update_cwd
 }
 


### PR DESCRIPTION
Closes #174 by adding isterm special characters on the precmd hook instead of just on initial shell init.

![image](https://github.com/microsoft/inshellisense/assets/35637443/406fd643-f77d-41fd-b70e-10c933657620)
