### PR TITLE
Update inshellisense commands and options

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,13 @@ After completing the installation, you can run `is` to start the autocomplete se
 
 ### Usage
 
-| Action                                | Command |
-| ------------------------------------- | ------- |
-| Start                                 | `is`    |
-| Stop                                  | `exit`  |
-| Check If Inside Inshellisense Session | `is -c` |
+| Action                                | Command                           | Description                                      |
+| ------------------------------------- | --------------------------------- | ------------------------------------------------ |
+| Start                                 | `is`                              | Start inshellisense session on the current shell |
+| Stop                                  | `exit`                            | Stop inshellisense session on the current shell  |
+| Check If Inside Inshellisense Session | `is -c`                           | Check if shell inside inshellisense session      |
+| Exit parent terminal                  | `is -p` or `is --parent-term-exit`| Exit parent terminal on exit, if exists. Useful for adding is to shell startup scripts like `~/.bashrc` or `~/.zshrc` |
+
 
 #### Keybindings
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ After completing the installation, you can run `is` to start the autocomplete se
 | Start                                 | `is`                              | Start inshellisense session on the current shell |
 | Stop                                  | `exit`                            | Stop inshellisense session on the current shell  |
 | Check If Inside Inshellisense Session | `is -c`                           | Check if shell inside inshellisense session      |
-| Exit parent terminal                  | `is -p` or `is --parent-term-exit`| Exit parent terminal on exit, if exists. Useful for adding is to shell startup scripts like `~/.bashrc` or `~/.zshrc` |
 
 
 #### Keybindings

--- a/src/commands/root.ts
+++ b/src/commands/root.ts
@@ -15,6 +15,7 @@ type RootCommandOptions = {
   verbose: boolean | undefined;
   check: boolean | undefined;
   test: boolean | undefined;
+  parentTermExit: boolean | undefined;
 };
 
 export const action = (program: Command) => async (options: RootCommandOptions) => {
@@ -40,5 +41,5 @@ export const action = (program: Command) => async (options: RootCommandOptions) 
   } else if (shell == Shell.Bash) {
     await setupBashPreExec();
   }
-  await render(shell, options.test ?? false);
+  await render(shell, options.test ?? false, options.parentTermExit ?? false);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ program
   .action(action(program))
   .option("-s, --shell <shell>", `shell to use for command execution, supported shells: ${supportedShells}`)
   .option("-c, --check", `check if shell is in an inshellisense session`)
-  .option("-p, --parent-term-exit", `if the terminal with inshellisense is closed, exit the parent terminal`)
+  .option("--parent-term-exit", `when inshellisense is closed, kill the parent process`)
   .addOption(hiddenOption("-T, --test", "used to make e2e tests reproducible across machines"))
   .option("-V, --verbose", `enable verbose logging`)
   .showHelpAfterError("(add --help for additional information)");

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ program
   .action(action(program))
   .option("-s, --shell <shell>", `shell to use for command execution, supported shells: ${supportedShells}`)
   .option("-c, --check", `check if shell is in an inshellisense session`)
+  .option("-p, --parent-term-exit", `if the terminal with inshellisense is closed, exit the parent terminal`)
   .addOption(hiddenOption("-T, --test", "used to make e2e tests reproducible across machines"))
   .option("-V, --verbose", `enable verbose logging`)
   .showHelpAfterError("(add --help for additional information)");

--- a/src/ui/ui-root.ts
+++ b/src/ui/ui-root.ts
@@ -16,7 +16,7 @@ export const renderConfirmation = (live: boolean): string => {
   return `inshellisense session [${statusMessage}]\n`;
 };
 
-export const render = async (shell: Shell, underTest: boolean) => {
+export const render = async (shell: Shell, underTest: boolean, parentTermExit: boolean) => {
   const term = await isterm.spawn({ shell, rows: process.stdout.rows, cols: process.stdout.columns, underTest });
   const suggestionManager = new SuggestionManager(term, shell);
   let hasActiveSuggestions = false;
@@ -140,6 +140,9 @@ export const render = async (shell: Shell, underTest: boolean) => {
   });
 
   term.onExit(({ exitCode }) => {
+    if (parentTermExit && process.ppid) {
+      process.kill(process.ppid);
+    }
     process.exit(exitCode);
   });
   process.stdout.on("resize", () => {


### PR DESCRIPTION
# Description
This pull request solves #194 

# How is it solved

A new flag is added: `parent-term-exit` which allows users to opt in on closing any parent shells when `is` is started. This is useful for adding is to a `~/.zshrc` configuration.