### PR TITLE
fix: for filepaths/folders templates, the icon type of the suggestion…

### DIFF
--- a/src/runtime/template.ts
+++ b/src/runtime/template.ts
@@ -6,12 +6,21 @@ import log from "../utils/log.js";
 
 const filepathsTemplate = async (cwd: string): Promise<Fig.TemplateSuggestion[]> => {
   const files = await fsAsync.readdir(cwd, { withFileTypes: true });
-  return files.filter((f) => f.isFile() || f.isDirectory()).map((f) => ({ name: f.name, priority: 55, context: { templateType: "filepaths" } }));
+  return files
+    .filter((f) => f.isFile() || f.isDirectory())
+    .map((f) => ({ name: f.name, priority: 55, context: { templateType: "filepaths" }, type: f.isDirectory() ? "folder" : "file" }));
 };
 
 const foldersTemplate = async (cwd: string): Promise<Fig.TemplateSuggestion[]> => {
   const files = await fsAsync.readdir(cwd, { withFileTypes: true });
-  return files.filter((f) => f.isDirectory()).map((f) => ({ name: f.name, priority: 55, context: { templateType: "folders" } }));
+  return files
+    .filter((f) => f.isDirectory())
+    .map((f) => ({
+      name: f.name,
+      priority: 55,
+      context: { templateType: "folders" },
+      type: "folder",
+    }));
 };
 
 // TODO: implement history template

--- a/src/tests/runtime/__snapshots__/runtime.test.ts.snap
+++ b/src/tests/runtime/__snapshots__/runtime.test.ts.snap
@@ -505,7 +505,7 @@ exports[`parseCommand optionsSuggestedAfterVariadicArg 1`] = `
         "package-lock.json",
       ],
       "description": undefined,
-      "icon": "📀",
+      "icon": "📄",
       "insertValue": undefined,
       "name": "package-lock.json",
       "priority": 55,
@@ -567,6 +567,42 @@ exports[`parseCommand partialPrefixFilter 1`] = `
       "insertValue": undefined,
       "name": "stash",
       "priority": 50,
+    },
+  ],
+}
+`;
+
+exports[`parseCommand provideFileSuggestion 1`] = `
+{
+  "charactersToDrop": 4,
+  "suggestions": [
+    {
+      "allNames": [
+        "README.md",
+      ],
+      "description": undefined,
+      "icon": "📄",
+      "insertValue": undefined,
+      "name": "README.md",
+      "priority": 55,
+    },
+  ],
+}
+`;
+
+exports[`parseCommand provideFolderSuggestion 1`] = `
+{
+  "charactersToDrop": 2,
+  "suggestions": [
+    {
+      "allNames": [
+        "src",
+      ],
+      "description": undefined,
+      "icon": "📁",
+      "insertValue": undefined,
+      "name": "src",
+      "priority": 55,
     },
   ],
 }

--- a/src/tests/runtime/runtime.test.ts
+++ b/src/tests/runtime/runtime.test.ts
@@ -13,6 +13,8 @@ const testData = [
   { name: "exclusiveOnOption", command: "ag --affinity --no" },
   { name: "providedSuggestion", command: "bw completion --shell " },
   { name: "fullyTypedSuggestion", command: "ls -W" },
+  { name: "provideFolderSuggestion", command: "ls sr" },
+  { name: "provideFileSuggestion", command: "ls READ" },
   { name: "optionsSuggestedAfterVariadicArg", command: "ls item -l", maxSuggestions: 3 },
   { name: "noOptionsSuggestedDuringVariadicArg", command: "ls -W ite" },
   { name: "providedArgDescription", command: "act completion bash -a " },

--- a/src/tests/ui/autocomplete.test.ts
+++ b/src/tests/ui/autocomplete.test.ts
@@ -68,7 +68,7 @@ shells.map((activeShell) => {
       await expect(terminal.getByText(">  ")).toBeVisible();
       terminal.write("ls ");
 
-      await expect(terminal.getByText("📀", { strict: false })).toBeVisible();
+      await expect(terminal.getByText("📄", { strict: false })).toBeVisible();
     });
 
     test("tab completion", async ({ terminal }) => {


### PR DESCRIPTION
For filepaths / folder templates, the icon type of the suggestion needs to be specified to avoid going to the default icon.

thanks for the review.
@cpendery

<img width="789" alt="image" src="https://github.com/microsoft/inshellisense/assets/9245110/14b7235a-6528-4966-bb04-d85feb5af1cc">
