### PR TITLE
fix: alt buffer issue when entering vi

### DIFF
--- a/src/isterm/commandManager.ts
+++ b/src/isterm/commandManager.ts
@@ -227,9 +227,11 @@ export class CommandManager {
       this.#activeCommand.promptEndMarker = this.#terminal.registerMarker(0);
     }
 
+    if (this.#activeCommand.promptEndMarker == null) return;
+
     // if we haven't fond the prompt yet, poll over the next 5 lines searching for it
     if (this.#activeCommand.promptText == null && withinPollDistance) {
-      for (let i = globalCursorPosition; i < this.#activeCommand.promptEndMarker!.line + maxPromptPollDistance; i++) {
+      for (let i = globalCursorPosition; i < this.#activeCommand.promptEndMarker.line + maxPromptPollDistance; i++) {
         if (this.#previousCommandLines.has(i)) continue;
         const promptResult = this._getWindowsPrompt(i);
         if (promptResult != null) {


### PR DESCRIPTION
Closes #205. Triggered by the active markers nulling during the `vi` alt buffer (expected xterm behavior). 