### PR TITLE
feat: Add support for local autocomplete specs path configuration

### DIFF
--- a/src/commands/root.ts
+++ b/src/commands/root.ts
@@ -8,6 +8,7 @@ import { loadConfig } from "../utils/config.js";
 import { Command } from "commander";
 import log from "../utils/log.js";
 import { loadAliases } from "../runtime/alias.js";
+import { loadLocalSpecsSet } from "../runtime/runtime.js";
 
 export const supportedShells = shells.join(", ");
 
@@ -29,6 +30,8 @@ export const action = (program: Command) => async (options: RootCommandOptions) 
   if (options.verbose) await log.enable();
 
   await loadConfig(program);
+
+  await loadLocalSpecsSet();
 
   const shell = options.shell ?? ((await inferShell()) as unknown as Shell | undefined);
   if (shell == null) {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -37,6 +37,9 @@ type Config = {
     nu?: PromptPattern[];
     powershell?: PromptPattern[];
   };
+  specs?: {
+    path?: string[];
+  };
 };
 
 const bindingSchema: JSONSchemaType<Binding> = {
@@ -63,6 +66,12 @@ const promptPatternsSchema: JSONSchemaType<PromptPattern[]> = {
   },
 };
 
+const specPathsSchema: JSONSchemaType<string[]> = {
+  type: "array",
+  items: { type: "string" },
+  nullable: true,
+};
+
 const configSchema = {
   type: "object",
   nullable: true,
@@ -86,6 +95,13 @@ const configSchema = {
         powershell: promptPatternsSchema,
         xonsh: promptPatternsSchema,
         nu: promptPatternsSchema,
+      },
+    },
+    specs: {
+      type: "object",
+      nullable: true,
+      properties: {
+        path: specPathsSchema,
       },
     },
   },
@@ -132,6 +148,9 @@ export const loadConfig = async (program: Command) => {
         xonsh: config.prompt?.xonsh,
         pwsh: config.prompt?.pwsh,
         nu: config.prompt?.nu,
+      },
+      specs: {
+        path: [`${os.homedir()}/.fig/autocomplete/build`, ...(config?.specs?.path ?? [])],
       },
     };
   }


### PR DESCRIPTION
A new configuration option 'specs.path' has been added to allow users to specify a local directory for autocomplete specs. Function loadLocalSpecsSet introduced to load local autocomplete specs from the specified path. The loading of local specs has been integrated into the startup routine.

fixed https://github.com/microsoft/inshellisense/issues/83

@cpendery I realized a version of loading any path, local complementary specification. Do you see OK.

If it's ok, I'll submit the corresponding UT test again. Thanks.

## specs
<img width="462" alt="image" src="https://github.com/microsoft/inshellisense/assets/9245110/84089586-adb5-4d05-a6a4-eed17f0a3d2c">


## is-config 

<img width="570" alt="image" src="https://github.com/microsoft/inshellisense/assets/9245110/18c59816-040e-4eb2-b186-5f6e23385744">

## usage

<img width="995" alt="image" src="https://github.com/microsoft/inshellisense/assets/9245110/84adf619-88f8-4ee1-945b-41c0552c64ec">
