### PR TITLE
fix: prompt terminator replay giving bad suggestions

### DIFF
--- a/src/isterm/commandManager.ts
+++ b/src/isterm/commandManager.ts
@@ -54,6 +54,8 @@ export class CommandManager {
   }
 
   handlePromptEnd() {
+    if (this.#activeCommand.promptEndMarker != null) return;
+
     this.#activeCommand.promptEndMarker = this.#terminal.registerMarker(0);
     if (this.#activeCommand.promptEndMarker?.line === this.#terminal.buffer.active.cursorY) {
       this.#activeCommand.promptEndX = this.#terminal.buffer.active.cursorX;
@@ -275,7 +277,7 @@ export class CommandManager {
         }
       }
 
-      const cursorAtEndOfInput = (this.#activeCommand.promptText.length + command.trim().length) % this.#terminal.cols <= this.#terminal.buffer.active.cursorX;
+      const cursorAtEndOfInput = (this.#activeCommand.promptText.length + command.trimEnd().length) % this.#terminal.cols <= this.#terminal.buffer.active.cursorX;
       let hasOutput = false;
 
       let cell = undefined;
@@ -288,7 +290,7 @@ export class CommandManager {
         }
       }
 
-      const commandPostfix = this.#activeCommand.promptText.length + command.trim().length < this.#terminal.buffer.active.cursorX ? " " : "";
+      const commandPostfix = this.#activeCommand.promptText.length + command.trimEnd().length < this.#terminal.buffer.active.cursorX ? " " : "";
       this.#activeCommand.persistentOutput = this.#activeCommand.hasOutput && hasOutput;
       this.#activeCommand.hasOutput = hasOutput;
       this.#activeCommand.suggestionsText = suggestions.trim();

--- a/src/isterm/commandManager.ts
+++ b/src/isterm/commandManager.ts
@@ -277,7 +277,8 @@ export class CommandManager {
         }
       }
 
-      const cursorAtEndOfInput = (this.#activeCommand.promptText.length + command.trimEnd().length) % this.#terminal.cols <= this.#terminal.buffer.active.cursorX;
+      const cursorAtEndOfInput =
+        (this.#activeCommand.promptText.length + command.trimEnd().length) % this.#terminal.cols <= this.#terminal.buffer.active.cursorX;
       let hasOutput = false;
 
       let cell = undefined;


### PR DESCRIPTION
Fixes #208. The issue is that the `@ ` is getting detected as terminating at the `@` so the space becomes part of the command. When calculating if the cursor is at the end of the command, it used `trim` instead of `trimEnd` so the cursor was always found to be 1 character left of the end giving recommendations too early. 