### PR TITLE
fix: infinite loop on clear command

### DIFF
--- a/src/isterm/commandManager.ts
+++ b/src/isterm/commandManager.ts
@@ -259,7 +259,7 @@ export class CommandManager {
       let wrappedCommand = "";
       let suggestions = "";
       let isWrapped = false;
-      for (; lineY < this.#terminal.rows; ) {
+      for (; lineY < this.#terminal.buffer.active.baseY + this.#terminal.rows; ) {
         for (let i = lineY == this.#activeCommand.promptEndMarker!.line ? this.#activeCommand.promptText.length : 0; i < this.#terminal.cols; i++) {
           if (command.endsWith("    ")) break; // assume that a command that ends with 4 spaces is terminated, avoids capturing right prompts
           const cell = line?.getCell(i);

--- a/src/isterm/commandManager.ts
+++ b/src/isterm/commandManager.ts
@@ -259,7 +259,7 @@ export class CommandManager {
       let wrappedCommand = "";
       let suggestions = "";
       let isWrapped = false;
-      for (;;) {
+      for (; lineY < this.#terminal.rows; ) {
         for (let i = lineY == this.#activeCommand.promptEndMarker!.line ? this.#activeCommand.promptText.length : 0; i < this.#terminal.cols; i++) {
           if (command.endsWith("    ")) break; // assume that a command that ends with 4 spaces is terminated, avoids capturing right prompts
           const cell = line?.getCell(i);


### PR DESCRIPTION
When clear runs, we could get caught in an infinite loop as no command would be found, limit the search size to the visible terminal buffer. 