### PR TITLE
fix: support more terminal accents & reset accents between different cells

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@homebridge/node-pty-prebuilt-multiarch": "^0.11.12",
         "@withfig/autocomplete": "2.651.0",
-        "@xterm/headless": "^5.3.0",
+        "@xterm/headless": "^5.5.0",
         "ajv": "^8.12.0",
         "ansi-escapes": "^6.2.0",
         "ansi-styles": "^6.2.1",
@@ -39,6 +39,7 @@
         "@typescript-eslint/eslint-plugin": "^6.7.4",
         "@typescript-eslint/parser": "^6.7.4",
         "@withfig/autocomplete-types": "^1.28.0",
+        "@xterm/xterm": "^5.5.0",
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-header": "^3.1.1",
@@ -2406,9 +2407,15 @@
       "dev": true
     },
     "node_modules/@xterm/headless": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@xterm/headless/-/headless-5.4.0.tgz",
-      "integrity": "sha512-CrFsRbkdGe4w8RExNPuXCceJ71ZBPHNJSM4pIbB31ioJj4Bgx51xjc6825m9Ftqfy3Bc9JpHhC8zeFvFeGx9Hg=="
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@xterm/headless/-/headless-5.5.0.tgz",
+      "integrity": "sha512-5xXB7kdQlFBP82ViMJTwwEc3gKCLGKR/eoxQm4zge7GPBl86tCdI0IdPJjoKd8mUSFXz5V7i/25sfsEkP4j46g=="
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
+      "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
+      "dev": true
     },
     "node_modules/acorn": {
       "version": "8.10.0",
@@ -10806,9 +10813,15 @@
       "dev": true
     },
     "@xterm/headless": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@xterm/headless/-/headless-5.4.0.tgz",
-      "integrity": "sha512-CrFsRbkdGe4w8RExNPuXCceJ71ZBPHNJSM4pIbB31ioJj4Bgx51xjc6825m9Ftqfy3Bc9JpHhC8zeFvFeGx9Hg=="
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@xterm/headless/-/headless-5.5.0.tgz",
+      "integrity": "sha512-5xXB7kdQlFBP82ViMJTwwEc3gKCLGKR/eoxQm4zge7GPBl86tCdI0IdPJjoKd8mUSFXz5V7i/25sfsEkP4j46g=="
+    },
+    "@xterm/xterm": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
+      "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
+      "dev": true
     },
     "acorn": {
       "version": "8.10.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@homebridge/node-pty-prebuilt-multiarch": "^0.11.12",
     "@withfig/autocomplete": "2.651.0",
+    "@xterm/headless": "^5.5.0",
     "ajv": "^8.12.0",
     "ansi-escapes": "^6.2.0",
     "ansi-styles": "^6.2.1",
@@ -51,8 +52,7 @@
     "toml": "^3.0.0",
     "wcwidth": "^1.0.1",
     "which": "^4.0.0",
-    "wrap-ansi": "^8.1.0",
-    "@xterm/headless": "^5.3.0"
+    "wrap-ansi": "^8.1.0"
   },
   "devDependencies": {
     "@microsoft/tui-test": "^0.0.1-rc.3",
@@ -65,6 +65,7 @@
     "@typescript-eslint/eslint-plugin": "^6.7.4",
     "@typescript-eslint/parser": "^6.7.4",
     "@withfig/autocomplete-types": "^1.28.0",
+    "@xterm/xterm": "^5.5.0",
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-header": "^3.1.1",

--- a/src/isterm/pty.ts
+++ b/src/isterm/pty.ts
@@ -12,6 +12,7 @@ import pty, { IPty, IEvent } from "@homebridge/node-pty-prebuilt-multiarch";
 import { Shell, userZdotdir, zdotdir } from "../utils/shell.js";
 import { IsTermOscPs, IstermOscPt, IstermPromptStart, IstermPromptEnd } from "../utils/ansi.js";
 import xterm from "@xterm/headless";
+import type { ICellData } from "@xterm/xterm/src/common/Types.js";
 import { CommandManager, CommandState } from "./commandManager.js";
 import log from "../utils/log.js";
 import { gitBashPath } from "../utils/shell.js";
@@ -176,28 +177,43 @@ export class ISTerm implements IPty {
     };
   }
 
-  private _sameAccent(baseCell: xterm.IBufferCell | undefined, targetCell: xterm.IBufferCell | undefined) {
-    return baseCell?.isBold() == targetCell?.isBold() && baseCell?.isItalic() == targetCell?.isItalic() && baseCell?.isUnderline() == targetCell?.isUnderline();
+  private _sameAccent(baseCell: ICellData | undefined, targetCell: ICellData | undefined) {
+    return (
+      baseCell?.isBold() == targetCell?.isBold() &&
+      baseCell?.isItalic() == targetCell?.isItalic() &&
+      baseCell?.isUnderline() == targetCell?.isUnderline() &&
+      baseCell?.extended.underlineStyle == targetCell?.extended.underlineStyle &&
+      baseCell?.hasExtendedAttrs() == targetCell?.hasExtendedAttrs() &&
+      baseCell?.isInverse() == targetCell?.isInverse() &&
+      baseCell?.isBlink() == targetCell?.isBlink() &&
+      baseCell?.isInvisible() == targetCell?.isInvisible() &&
+      baseCell?.isDim() == targetCell?.isDim() &&
+      baseCell?.isStrikethrough() == targetCell?.isStrikethrough()
+    );
   }
 
-  private _getAnsiAccents(cell: xterm.IBufferCell | undefined): string {
+  private _getAnsiAccents(cell: ICellData | undefined): string {
     if (cell == null) return "";
-    let boldAnsi = "";
-    if (cell.isBold()) {
-      boldAnsi = "\x1b[1m";
-    }
-    let italicAnsi = "";
-    if (cell.isItalic()) {
-      italicAnsi = "\x1b[3m";
-    }
     let underlineAnsi = "";
     if (cell.isUnderline()) {
-      underlineAnsi = "\x1b[4m";
+      if (cell.hasExtendedAttrs() && cell.extended.underlineStyle) {
+        underlineAnsi = `\x1b[4:${cell.extended.underlineStyle}m`;
+      } else {
+        underlineAnsi = "\x1b[4m";
+      }
     }
-    return boldAnsi + italicAnsi + underlineAnsi;
+    const boldAnsi = cell.isBold() ? "\x1b[1m" : "";
+    const dimAnsi = cell.isDim() ? "\x1b[2m" : "";
+    const italicAnsi = cell.isItalic() ? "\x1b[3m" : "";
+    const blinkAnsi = cell.isBlink() ? "\x1b[5m" : "";
+    const inverseAnsi = cell.isInverse() ? "\x1b[7m" : "";
+    const invisibleAnsi = cell.isInvisible() ? "\x1b[8m" : "";
+    const strikethroughAnsi = cell.isStrikethrough() ? "\x1b[9m" : "";
+
+    return boldAnsi + italicAnsi + underlineAnsi + inverseAnsi + dimAnsi + blinkAnsi + invisibleAnsi + strikethroughAnsi;
   }
 
-  private _sameColor(baseCell: xterm.IBufferCell | undefined, targetCell: xterm.IBufferCell | undefined) {
+  private _sameColor(baseCell: ICellData | undefined, targetCell: ICellData | undefined) {
     return (
       baseCell?.getBgColorMode() == targetCell?.getBgColorMode() &&
       baseCell?.getBgColor() == targetCell?.getBgColor() &&
@@ -206,7 +222,7 @@ export class ISTerm implements IPty {
     );
   }
 
-  private _getAnsiColors(cell: xterm.IBufferCell | undefined): string {
+  private _getAnsiColors(cell: ICellData | undefined): string {
     if (cell == null) return "";
     let bgAnsi = "";
     cell.getBgColor;
@@ -236,14 +252,20 @@ export class ISTerm implements IPty {
       const line = this.#term.buffer.active.getLine(y);
       const ansiLine = ["\x1b[0m"];
       if (line == null) return "";
-      let prevCell: xterm.IBufferCell | undefined;
+      let prevCell: ICellData | undefined;
       for (let x = 0; x < line.length; x++) {
-        const cell = line.getCell(x);
+        const cell = line.getCell(x) as unknown as ICellData | undefined;
         const chars = cell?.getChars() ?? "";
-        if (!this._sameColor(prevCell, cell)) {
+
+        const sameColor = this._sameColor(prevCell, cell);
+        const sameAccents = this._sameAccent(prevCell, cell);
+        if (!sameColor || !sameAccents) {
+          ansiLine.push("\x1b[0m");
+        }
+        if (!sameColor) {
           ansiLine.push(this._getAnsiColors(cell));
         }
-        if (!this._sameAccent(prevCell, cell)) {
+        if (!sameAccents) {
           ansiLine.push(this._getAnsiAccents(cell));
         }
         ansiLine.push(chars == "" ? " " : chars);


### PR DESCRIPTION
Before: 
![image](https://github.com/microsoft/inshellisense/assets/35637443/33a072d8-98ee-48ed-bb0e-5b021579ba62)
After: 
![image](https://github.com/microsoft/inshellisense/assets/35637443/806abec5-898b-4cb5-862a-5d13574097a5)

Note underlines are hidden due to a bug in vscode, see https://github.com/microsoft/vscode/issues/210326