### PR TITLE
fix: clears on windows ptys

### DIFF
--- a/src/isterm/commandManager.ts
+++ b/src/isterm/commandManager.ts
@@ -236,6 +236,7 @@ export class CommandManager {
     if (globalCursorPosition < this.#activeCommand.promptStartMarker.line) {
       this.handleClear();
       this.#activeCommand.promptEndMarker = this.#terminal.registerMarker(0);
+      return;
     }
 
     if (this.#activeCommand.promptEndMarker == null) return;


### PR DESCRIPTION
Approximated clears weren't working on windows pty's since the prompt would get detected twice. Instead, once a clear is detected, it should terminate the `termSync` and wait for the next action to occur.