### PR TITLE
fix: suggestion appears and hangs after enter

### DIFF
--- a/src/ui/suggestionManager.ts
+++ b/src/ui/suggestionManager.ts
@@ -161,6 +161,9 @@ export class SuggestionManager {
 
   update(keyPress: KeyPress): boolean {
     const { name, shift, ctrl } = keyPress;
+    if (name == "return") {
+      this.#term.clearCommand(); // clear the current command on enter
+    }
     if (!this.#suggestBlob) {
       return false;
     }
@@ -186,9 +189,6 @@ export class SuggestionManager {
       }
       this.#term.write(removals + chars);
     } else {
-      if (name == "return") {
-        this.#term.clearCommand(); // clear the current command on enter
-      }
       return false;
     }
     log.debug({ msg: "handled keypress", ...keyPress });


### PR DESCRIPTION
I missed the case in #234 where a suggestion erroneously appears after a user hits enter because of whitespace detected when there was no suggestion at the point of hitting enter. This moves the command clearing above the check for suggestions so that it is always cleared, even if suggestions are visible or not