### PR TITLE
fix: zsh configs on macos

### DIFF
--- a/shell/shellIntegration-env.zsh
+++ b/shell/shellIntegration-env.zsh
@@ -1,9 +1,12 @@
 if [[ -f $USER_ZDOTDIR/.zshenv ]]; then
+	IS_ZDOTDIR=$ZDOTDIR
 	ZDOTDIR=$USER_ZDOTDIR
 
 	# prevent recursion
-	if [[ $USER_ZDOTDIR != $ZDOTDIR ]]; then
-		ZDOTDIR=$USER_ZDOTDIR
+	if [[ $USER_ZDOTDIR != $IS_ZDOTDIR ]]; then
 		. $USER_ZDOTDIR/.zshenv
 	fi
+
+	USER_ZDOTDIR=$ZDOTDIR
+	ZDOTDIR=$IS_ZDOTDIR
 fi

--- a/shell/shellIntegration-rc.zsh
+++ b/shell/shellIntegration-rc.zsh
@@ -1,3 +1,5 @@
+autoload -U add-zsh-hook
+
 if [[ -f $USER_ZDOTDIR/.zshrc ]]; then
 	ZDOTDIR=$USER_ZDOTDIR
 	. $USER_ZDOTDIR/.zshrc


### PR DESCRIPTION
Fixes a configuration issue that causes inshellisense to fail when spawning on macOS with zsh

Related to #255 & #261