### PR TITLE
fix: generators that console log should be captured and redirected to logfile

### DIFF
--- a/src/commands/root.ts
+++ b/src/commands/root.ts
@@ -33,6 +33,8 @@ export const action = (program: Command) => async (options: RootCommandOptions) 
 
   await loadLocalSpecsSet();
 
+  log.overrideConsole();
+
   const shell = options.shell ?? ((await inferShell()) as unknown as Shell | undefined);
   if (shell == null) {
     program.error(`Unable to identify shell, use the -s/--shell option to provide your shell`, { exitCode: 1 });

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -30,7 +30,6 @@ const debug = (content: object) => {
   });
 };
 
-
 const getLogFunction =
   (level: "error" | "log") =>
   (...data: any[]) =>

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -29,16 +29,19 @@ const debug = (content: object) => {
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const getLogFunction = (level: "error" | "log") => (...data: any[]) => debug({msg: `console.${level}`, data: data.toString()});
+const getLogFunction =
+  (level: "error" | "log") =>
+  (...data: any[]) =>
+    debug({ msg: `console.${level}`, data: data.toString() });
 
 const logConsole = {
   ...console,
   log: getLogFunction("log"),
   error: getLogFunction("error"),
-}
+};
 
 // eslint-disable-next-line no-global-assign
-const overrideConsole = () => console = logConsole
+const overrideConsole = () => (console = logConsole);
 
 export const enable = async () => {
   await reset();

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import os from "node:os";
 import path from "node:path";
 import fs from "node:fs";
@@ -28,7 +30,7 @@ const debug = (content: object) => {
   });
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 const getLogFunction =
   (level: "error" | "log") =>
   (...data: any[]) =>

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -28,9 +28,21 @@ const debug = (content: object) => {
   });
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const getLogFunction = (level: "error" | "log") => (...data: any[]) => debug({msg: `console.${level}`, data: data.toString()});
+
+const logConsole = {
+  ...console,
+  log: getLogFunction("log"),
+  error: getLogFunction("error"),
+}
+
+// eslint-disable-next-line no-global-assign
+const overrideConsole = () => console = logConsole
+
 export const enable = async () => {
   await reset();
   logEnabled = true;
 };
 
-export default { reset, debug, enable };
+export default { reset, debug, enable, overrideConsole };


### PR DESCRIPTION
As seen in [autocomplete/pre-commit.ts](https://github.com/withfig/autocomplete/blob/master/src/pre-commit.ts), some generators have `console.log` & `console.error`. This PR captures those methods and redirects them to the logfile so those failures aren't bubbled up into the UI

Fixes #280