### PR TITLE
Fix fish shell integration when prompt function doesn't return anything

### DIFF
--- a/shell/shellIntegration.fish
+++ b/shell/shellIntegration.fish
@@ -20,4 +20,4 @@ if [ "$ISTERM_TESTING" = "1" ]
 	function is_user_prompt; printf '> '; end
 end
 
-function fish_prompt; printf (__is_prompt_start); printf (is_user_prompt); printf (__is_prompt_end); end
+function fish_prompt; __is_prompt_start; is_user_prompt; __is_prompt_end; end


### PR DESCRIPTION
The current integration printf's the user's prompt function as if it was a format string.
However, as the documentation for fish's printf builtin says:
"       It will also return non-zero if no argument at all was given, in which case it will *print nothing*"

The result is that there are plenty of cases where the printf function will print nothing at all when the prompt function does not return anything.   This is true despite using command substitution to try to get the output as a string.

This is all AFAICT, it's tricky to figure out exactly what happens.

Put another way, this will work fine:

```function fish_prompt; printf (__is_prompt_start); printf %s (is_user_prompt); printf (__is_prompt_end); end```

This will also work fine:
```function fish_prompt; printf (__is_prompt_start); is_user_prompt; printf (__is_prompt_end); end```

What exists now:
```function fish_prompt; printf (__is_prompt_start); printf (is_user_prompt); printf (__is_prompt_end); end``` will not always work.

It will result in displaying no user prompt in a large number of cases.

A screenshot is attached where you can see what happens. The printf returns and displays nothing.
both evaluation, and printf with %s + command substitution display the user prompt.

The same is technically true of the other two printfs, but for some reason they always seem to display output.
I wish i could say with certainty why this is.  However, one thing i can say with certainty - it will always be correct to simply execute the functions without printfs.
Internally, fish executes the prompt function in a subshell into a buffer and then displays it. 

So we do that for the user prompt.  I am happy to do it with the other two functions as well.

![Screenshot_20240921_140318](https://github.com/user-attachments/assets/74ac1169-0641-4e69-9294-359ccad89825)
