### PR TITLE
fix: use git bash for shell commands on windows to reduce generator failures

### DIFF
--- a/src/runtime/alias.ts
+++ b/src/runtime/alias.ts
@@ -9,7 +9,7 @@ import os from "node:os";
 
 const loadedAliases: { [key: string]: CommandToken[] | undefined } = {};
 const platform = os.platform();
-const executeShellCommand = buildExecuteShellCommand(5_000);
+const executeShellCommand = await buildExecuteShellCommand(5_000);
 
 const loadBashAliases = async () => {
   const shellTarget = platform == "win32" ? await gitBashPath() : Shell.Bash;

--- a/src/runtime/generator.ts
+++ b/src/runtime/generator.ts
@@ -21,7 +21,7 @@ export const runGenerator = async (generator: Fig.Generator, tokens: string[], c
   // TODO: support trigger
   const { script, postProcess, scriptTimeout, splitOn, custom, template, filterTemplateSuggestions } = generator;
 
-  const executeShellCommand = buildExecuteShellCommand(scriptTimeout ?? 5000);
+  const executeShellCommand = await buildExecuteShellCommand(scriptTimeout ?? 5000);
   const suggestions = [];
   try {
     if (script) {

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -146,7 +146,7 @@ const getSubcommand = (spec?: Fig.Spec): Fig.Subcommand | undefined => {
   return spec;
 };
 
-const executeShellCommand = buildExecuteShellCommand(5000);
+const executeShellCommand = await buildExecuteShellCommand(5000);
 
 const genSubcommand = async (command: string, parentCommand: Fig.Subcommand): Promise<Fig.Subcommand | undefined> => {
   if (!parentCommand.subcommands || parentCommand.subcommands.length === 0) return;

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -22,10 +22,28 @@ const getExecutionShell = async (): Promise<undefined | string> => {
   }
 };
 
+const bashSpecialCharacters = /[&|<>\s]/g;
+// escape whitespace & special characters in an argument when not quoted
+const shouldEscapeArg = (arg: string) => {
+  const hasSpecialCharacter = bashSpecialCharacters.test(arg);
+  const isSingleCharacter = arg.length === 1;
+  const isQuoted = (arg.startsWith(`"`) && arg.endsWith(`"`)) || (arg.startsWith(`'`) && arg.endsWith(`'`));
+  return hasSpecialCharacter && !isSingleCharacter && !isQuoted;
+};
+
+/* based on libuv process.c used by nodejs, only quotes are escaped for shells. if using git bash need to escape whitespace & special characters in an argument */
+const escapeArgs = (shell: string | undefined, args: string[]) => {
+  // only escape args for git bash
+  if (process.platform !== "win32" || shell == undefined) return args;
+  return args.map((arg) => (shouldEscapeArg(arg) ? `"${arg.replaceAll('"', '\\"')}"` : arg));
+};
+
 export const buildExecuteShellCommand =
   async (timeout: number): Promise<Fig.ExecuteCommandFunction> =>
   async ({ command, env, args, cwd }: Fig.ExecuteCommandInput): Promise<Fig.ExecuteCommandOutput> => {
-    const child = spawn(command, args, { cwd, env: { ...process.env, ...env, ISTERM: "1" }, shell: await getExecutionShell() });
+    const executionShell = await getExecutionShell();
+    const escapedArgs = escapeArgs(executionShell, args);
+    const child = spawn(command, escapedArgs, { cwd, env: { ...process.env, ...env, ISTERM: "1" }, shell: executionShell });
     setTimeout(() => child.kill("SIGKILL"), timeout);
     let stdout = "";
     let stderr = "";


### PR DESCRIPTION
There is a constraint with the current [cd spec](https://github.com/withfig/autocomplete/blob/master/src/cd.ts) from fig. It uses `ls -1ApL` to [generate the folder list](https://github.com/withfig/autocomplete-tools/blob/98cd68410a07a78ac805a2de3873ee852e2bda36/generators/src/filepaths.ts#L178-L179), which will fail in pwsh. 

This PR addresses the issue by using Git Bash for generators on Windows. On Linux, having `/bin/sh` as a default will already fix this issue. Users without Git Bash installed will still have issues with cd, but that is an issue at the Fig spec level. I don't want to bring custom specs into inshellisense, so this is the best solution for now.

Closes #12 