### PR TITLE
feat: update shell config system

### DIFF
--- a/.scripts/postinstall.js
+++ b/.scripts/postinstall.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import fs from "node:fs";
 
 if (fs.existsSync("./build/commands/init.js")) {

--- a/.scripts/postinstall.js
+++ b/.scripts/postinstall.js
@@ -1,0 +1,6 @@
+import fs from "node:fs";
+
+if (fs.existsSync("./build/commands/init.js")) {
+  const init = (await import("../build/commands/init.js")).default;
+  init.parse(["--generate-full-configs"], { from: "user" });
+}

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install -g @microsoft/inshellisense
 
 ### Quickstart
 
-After completing the installation, you can run `is` to start the autocomplete session for your desired shell. Additionally, inshellisense is also aliased under `inshellisense` after installation.
+After completing the installation, run `is doctor` to verify your installation was successful. You can run `is` to start the autocomplete session for your desired shell. Additionally, inshellisense is also aliased under `inshellisense` after installation.
 
 ### Shell Plugin
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@microsoft/inshellisense",
       "version": "0.0.1-rc.16",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@homebridge/node-pty-prebuilt-multiarch": "^0.11.12",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "lint": "eslint src/ --ext .ts,.tsx && prettier src/ --check",
     "lint:fix": "eslint src/ --ext .ts,.tsx --fix && prettier src/ --write",
     "debug": "node --inspect --import=tsx src/index.ts -V",
-    "pre-commit": "lint-staged"
+    "pre-commit": "lint-staged",
+    "postinstall": "node ./build/index.js init --generate-full-configs"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint:fix": "eslint src/ --ext .ts,.tsx --fix && prettier src/ --write",
     "debug": "node --inspect --import=tsx src/index.ts -V",
     "pre-commit": "lint-staged",
-    "postinstall": "node ./build/index.js init --generate-full-configs"
+    "postinstall": "node ./.scripts/postinstall.js"
   },
   "repository": {
     "type": "git",

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Command } from "commander";
+import { render } from "../ui/ui-doctor.js";
+
+const action = async () => {
+  await render();
+};
+
+const cmd = new Command("doctor");
+cmd.description(`checks the health of this inshellisense installation`);
+cmd.action(action);
+
+export default cmd;

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import complete from "./commands/complete.js";
 import uninstall from "./commands/uninstall.js";
 import init from "./commands/init.js";
 import specs from "./commands/specs/root.js";
+import doctor from "./commands/doctor.js";
 import { action, supportedShells } from "./commands/root.js";
 import { getVersion } from "./utils/version.js";
 
@@ -39,5 +40,6 @@ program.addCommand(complete);
 program.addCommand(uninstall);
 program.addCommand(init);
 program.addCommand(specs);
+program.addCommand(doctor);
 
 program.parse();

--- a/src/ui/ui-doctor.ts
+++ b/src/ui/ui-doctor.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import chalk from "chalk";
+import { checkLegacyConfigs, checkShellConfigs } from "../utils/shell.js";
+
+export const render = async () => {
+  let errors = 0;
+  errors += await renderLegacyConfigIssues();
+  errors += renderShellConfigIssues();
+
+  process.exit(errors);
+};
+
+const renderLegacyConfigIssues = async (): Promise<number> => {
+  const shellsWithLegacyConfigs = await checkLegacyConfigs();
+  if (shellsWithLegacyConfigs.length > 0) {
+    process.stderr.write(chalk.red("•") + chalk.bold(" detected legacy configurations\n"));
+    process.stderr.write("  the following shells have legacy configurations:\n");
+    shellsWithLegacyConfigs.forEach((shell) => {
+      process.stderr.write(chalk.red("  - ") + shell + "\n");
+    });
+    process.stderr.write(
+      chalk.yellow("  remove any inshellisense configurations from your shell profile and re-add them following the instructions in the README\n"),
+    );
+    return 1;
+  } else {
+    process.stdout.write(chalk.green("✓") + " no legacy configurations found\n");
+  }
+  return 0;
+};
+
+const renderShellConfigIssues = (): number => {
+  const shellsWithoutConfigs = checkShellConfigs();
+  if (shellsWithoutConfigs.length > 0) {
+    process.stderr.write(chalk.red("•") + " the following shells do not have configurations:\n");
+    shellsWithoutConfigs.forEach((shell) => {
+      process.stderr.write(chalk.red("  - ") + shell + "\n");
+    });
+    process.stderr.write(chalk.yellow("  run " + chalk.underline(chalk.cyan("is init --generate-full-configs")) + " to generate new configurations\n"));
+    return 1;
+  } else {
+    process.stdout.write(chalk.green("✓") + " all shells have configurations\n");
+  }
+  return 0;
+};

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -167,9 +167,8 @@ export const loadConfig = async (program: Command) => {
   globalConfig.specs = { path: [`${os.homedir()}/.fig/autocomplete/build`, ...(globalConfig.specs?.path ?? [])] };
 };
 
-export const deleteCacheFolder = async (): Promise<void> => {
-  const cliConfigPath = path.join(os.homedir(), cachePath);
-  if (fs.existsSync(cliConfigPath)) {
-    fs.rmSync(cliConfigPath, { recursive: true });
+export const deleteCacheFolder = (): void => {
+  if (fs.existsSync(cachePath)) {
+    fs.rmSync(cachePath, { recursive: true });
   }
 };


### PR DESCRIPTION
This PR updates the shell config system so that all the shell configs are now placed under `~/.inshellisense/[shell]/[shell].[ext]`. The init command now only sources those files & they are automatically updated with each install. This will enable updating the configs without requiring user interaction (besides updating their installation) when required (ex. #266). 

It additionally adds a `doctor` command for identifying issues with a user's installation.