### PR TITLE
docs: fix save command for powershell

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ is init zsh >> ~/.zshrc
 is init fish >> ~/.config/fish/config.fish
 
 # pwsh
-is init pwsh >> $profile
+is init pwsh | Add-Content $profile
 
 # powershell
-is init powershell >> $profile
+is init powershell | Add-Content $profile
 
 # xonsh
 is init xonsh >> ~/.xonshrc


### PR DESCRIPTION
Fixes #287 as `>>` on Powershell < 5 adds null characters between every character. Swapping to using `Add-Content` instead