### PR TITLE
fix: shell integration for fish can break prompt layout

### DIFF
--- a/shell/shellIntegration.fish
+++ b/shell/shellIntegration.fish
@@ -20,4 +20,9 @@ if [ "$ISTERM_TESTING" = "1" ]
 	function is_user_prompt; printf '> '; end
 end
 
-function fish_prompt; __is_prompt_start; is_user_prompt; __is_prompt_end; end
+function fish_prompt;
+    set --local __user_prompt_lines (is_user_prompt)
+    set --local __user_prompt (string join '\n' $__user_prompt_lines)
+	set --local __prompt (string join '' (__is_prompt_start) $__user_prompt (__is_prompt_end))
+    printf $__prompt
+end


### PR DESCRIPTION
It used to be even worse before #288. Fixes #107

### Screenshots
#### Before
![image](https://github.com/user-attachments/assets/ecf35ced-5381-4b61-a9e7-b1fcbc351c42)
#### After
![image](https://github.com/user-attachments/assets/016e5679-05d1-4fcd-b959-06c76a70ee01)
