### PR TITLE
fix: wide cells on rewrite

### DIFF
--- a/src/isterm/pty.ts
+++ b/src/isterm/pty.ts
@@ -298,7 +298,9 @@ export class ISTerm implements IPty {
         if (!sameAccents) {
           ansiLine.push(this._getAnsiAccents(cell));
         }
-        ansiLine.push(chars == "" ? ansi.cursorForward() : chars);
+        const isWide = prevCell?.getWidth() == 2 && cell?.getWidth() == 0;
+        const cursorForward = isWide ? "" : ansi.cursorForward();
+        ansiLine.push(chars == "" ? cursorForward : chars);
         prevCell = cell;
       }
       return ansiLine.join("");


### PR DESCRIPTION
Fixes #175. The issue of the suggestions not moving the proper width had been fixed in a previous PR. This PR fixes the issue where extra spaces are added into content when clearing the suggestions for wide chars
 
### Screenshots
#### Before
https://github.com/user-attachments/assets/f3b29341-32bc-44a8-be8e-fd68b386a38d

#### After
https://github.com/user-attachments/assets/319ef81f-6083-4a6f-86a2-cf866f8a28cf

