### PR TITLE
fix: The if condition of __is_report_prompt should be more precise to prevent bash error prompts after each command.

### DIFF
--- a/shell/shellIntegration.bash
+++ b/shell/shellIntegration.bash
@@ -61,7 +61,7 @@ __is_update_cwd() {
 }
 
 __is_report_prompt() {
-	if ((BASH_VERSINFO[0] >= 4)); then
+	if ((BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] >= 4)); then
 		__is_prompt=${__is_original_PS1@P}
 	else
 		__is_prompt=${__is_original_PS1}


### PR DESCRIPTION
## [fix]: The if condition of __is_report_prompt should be more precise to prevent bash error prompts after each command.
The ${parameter@P} syntax was first introduced in Bash 4.4, as showed in [bash/CHANGES](https://github.com/bminor/bash/blob/master/CHANGES#L2946). Although the code checks for Bash version >= 4, it does not specify the minor version number. This causes Bash under 4.4 to report an error after each command is executed when using Inshellisense on an older stable platform such as CentOS7.

for example, my bash version is unfortunately v4.2.x, then bash warns every time I type a command and press Enter...
![image](https://github.com/user-attachments/assets/15d063b2-8fcd-427c-a844-5bf766ccb813)

## To Reproduce error
- use bash (4.0 <= version < 4.4)
- the latest Inshellisense

fixing is very simple, The if condition should be more precise, then everything is all right : )
