### PR TITLE
fix: add trailing newline in bashrc config to prevent shell errors

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -21,7 +21,7 @@ const action = (program: Command) => async (shell: string | undefined, options: 
     program.error(`Unsupported shell: '${shell}', supported shells: ${supportedShells}`, { exitCode: 1 });
   }
   const config = getShellSourceCommand(shell as Shell);
-  process.stdout.write(`\n\n${config}`);
+  process.stdout.write(`\n\n${config}\n`);
 };
 
 const cmd = new Command("init");


### PR DESCRIPTION

This PR resolves [#335](https://github.com/microsoft/inshellisense/issues/335).

### Summary

Fixes a bug where the configuration line appended to `.bashrc` by `inshellisense` lacks a trailing newline. This results in broken command concatenation if another tool (e.g., CUDA) appends config lines immediately after.

### What Changed

In `src/commands/init.ts`, added an explicit trailing newline to the `config` output:
```ts
process.stdout.write(`\n\n${config}\n`);
````

### Why It Matters

Without a newline, tools appending shell config to `.bashrc` (e.g., CUDA) may cause a malformed entry like:

```bash
[ -f ~/.inshellisense/bash/init.sh ] && source ~/.inshellisense/bash/init.shexport PATH=...
```

This breaks shell startup and leads to errors like:

```
bash: /home/user/.inshellisense/bash/init.shexport: No such file or directory
```

### Environment

* OS: Ubuntu 24.04.2 LTS
* Shell: Bash 5.2.21
* Node: 22.15.0
* `is` version: 0.0.1-rc.20

