### PR TITLE
fix: alias loading on windows

### DIFF
--- a/src/runtime/alias.ts
+++ b/src/runtime/alias.ts
@@ -13,7 +13,7 @@ const executeShellCommand = await buildExecuteShellCommand(5_000);
 
 const loadBashAliases = async () => {
   const shellTarget = platform == "win32" ? await gitBashPath() : Shell.Bash;
-  const { stdout, stderr, status } = await executeShellCommand({ command: shellTarget, args: ["-i", "-c", "alias"], cwd: process.cwd(), env: { ISTERM: "1" } });
+  const { stdout, stderr, status } = await executeShellCommand({ command: `'${shellTarget}'`, args: ["-i", "-c", "alias"], cwd: process.cwd(), env: { ISTERM: "1" } });
   if (status !== 0) {
     log.debug({ msg: "failed to load bash aliases", stderr, status });
     return;

--- a/src/runtime/alias.ts
+++ b/src/runtime/alias.ts
@@ -13,7 +13,12 @@ const executeShellCommand = await buildExecuteShellCommand(5_000);
 
 const loadBashAliases = async () => {
   const shellTarget = platform == "win32" ? await gitBashPath() : Shell.Bash;
-  const { stdout, stderr, status } = await executeShellCommand({ command: `'${shellTarget}'`, args: ["-i", "-c", "alias"], cwd: process.cwd(), env: { ISTERM: "1" } });
+  const { stdout, stderr, status } = await executeShellCommand({
+    command: `'${shellTarget}'`,
+    args: ["-i", "-c", "alias"],
+    cwd: process.cwd(),
+    env: { ISTERM: "1" },
+  });
   if (status !== 0) {
     log.debug({ msg: "failed to load bash aliases", stderr, status });
     return;


### PR DESCRIPTION
Alias loading can fail on paths with spaces in them on Windows. This PR fixes that by adding quotes around the shell target in the command