### PR TITLE
fix: suggestions don't appear after using history to view command after execution

### DIFF
--- a/src/ui/suggestionManager.ts
+++ b/src/ui/suggestionManager.ts
@@ -50,6 +50,9 @@ export class SuggestionManager {
 
   private async _loadSuggestions(): Promise<void> {
     const commandText = this.#term.getCommandState().commandText;
+    if (!commandText) {
+      this.#command = "";
+    }
     if (!commandText || this.#hideSuggestions) {
       this.#suggestBlob = undefined;
       this.#activeSuggestionIdx = 0;


### PR DESCRIPTION
Related to #337. It's the only issue I could replicate with the sequence

```bash
node -v
clear
# Press up arrow to recall node -v
node -v
# Press up arrow again to recall the first node -v and run it again
node -v
```