### PR TITLE
fix: don't add command to suggestion cache until suggestions complete loading

### DIFF
--- a/src/isterm/commandManager.ts
+++ b/src/isterm/commandManager.ts
@@ -76,7 +76,7 @@ export class CommandManager {
       const whitespace = " ".repeat(commandWhitespaceTerminationWidth);
       const whitespaceIdx = promptLineText.indexOf(whitespace);
       if (whitespaceIdx != -1) {
-        this.#activeCommand.promptText = promptLineText.substring(0, whitespaceIdx);
+        this.#activeCommand.promptText = promptLineText.substring(0, whitespaceIdx) + 1;
         this.#activeCommand.promptEndX = whitespaceIdx;
       }
     }

--- a/src/ui/suggestionManager.ts
+++ b/src/ui/suggestionManager.ts
@@ -57,8 +57,8 @@ export class SuggestionManager {
     if (commandText == this.#command) {
       return;
     }
-    this.#command = commandText;
     const suggestionBlob = await getSuggestions(commandText, this.#term.cwd, this.#shell);
+    this.#command = commandText;
     this.#suggestBlob = suggestionBlob;
     this.#activeSuggestionIdx = 0;
   }


### PR DESCRIPTION
An issue I was noticing with pwsh as it runs a little slower than git bash with `oh-my-posh`. Suggestions were loading, but not rendering.