### PR TITLE
fix: load local specs from rc.toml paths

### DIFF
--- a/src/tests/utils/config.test.ts
+++ b/src/tests/utils/config.test.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { jest } from "@jest/globals";
+import { Command } from "commander";
+
+describe("loadConfig", () => {
+  test("loads local spec paths as file system paths", async () => {
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "inshellisense-home-"));
+    const configDir = path.join(tempHome, ".config", "inshellisense");
+    const localSpecPath = path.join(tempHome, "local-specs");
+    const localSpecPathToml = localSpecPath.replace(/\\/g, "\\\\");
+
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.mkdirSync(localSpecPath, { recursive: true });
+    fs.writeFileSync(path.join(configDir, "rc.toml"), `[specs]\npath = ["${localSpecPathToml}"]\n`);
+
+    jest.resetModules();
+    jest.unstable_mockModule("node:os", () => ({
+      default: { homedir: () => tempHome },
+      homedir: () => tempHome,
+    }));
+
+    try {
+      const { loadConfig, getConfig } = await import("../../utils/config.js");
+
+      await loadConfig(new Command());
+
+      expect(getConfig().specs.path).toEqual([path.join(tempHome, ".fig", "autocomplete", "build"), localSpecPath]);
+      expect(getConfig().specs.path.every((p) => !p.startsWith("file:"))).toBe(true);
+    } finally {
+      fs.rmSync(tempHome, { recursive: true, force: true });
+      jest.resetModules();
+    }
+  });
+});

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -135,15 +135,15 @@ export const loadConfig = async (program: Command) => {
           dismissSuggestions: config?.bindings?.dismissSuggestions ?? globalConfig.bindings.dismissSuggestions,
         },
         specs: {
-          path: [...(config?.specs?.path ?? []), ...(config?.specs?.path ?? [])],
+          path: [...(config?.specs?.path ?? []), ...(globalConfig.specs?.path ?? [])],
         },
-        useAliases: config.useAliases ?? false,
-        useNerdFont: config?.useNerdFont ?? false,
-        maxSuggestions: config?.maxSuggestions ?? 5,
+        useAliases: config.useAliases ?? globalConfig.useAliases,
+        useNerdFont: config?.useNerdFont ?? globalConfig.useNerdFont,
+        maxSuggestions: config?.maxSuggestions ?? globalConfig.maxSuggestions,
       };
     }
   }
-  globalConfig.specs = { path: [path.join(os.homedir(), ".fig", "autocomplete", "build"), ...(globalConfig.specs?.path ?? [])].map((p) => `file:\\${p}`) };
+  globalConfig.specs = { path: [path.join(os.homedir(), ".fig", "autocomplete", "build"), ...(globalConfig.specs?.path ?? [])] };
 };
 
 export const deleteCacheFolder = (): void => {


### PR DESCRIPTION
## Summary\n- keep  entries as filesystem paths instead of converting them to  strings\n- fix config merge behavior for  and scalar flags so earlier values are preserved\n- add a regression test for loading local spec paths from \n\n## Testing\n- npm test -- src/tests/utils/config.test.ts\n- npm test -- src/tests/runtime/runtime.test.ts\n\nFixes #362