### PR TITLE
Fix history arrow handling with suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,14 +71,14 @@ is init nu | save $nu.env-path --append
 
 #### Keybindings
 
-All other keys are passed through to the shell. The keybindings below are only captured when the inshellisense suggestions are visible, otherwise they are passed through to the shell as well. These can be customized in the [config](#configuration).
+All other keys are passed through to the shell. The keybindings below are only captured when the inshellisense suggestions are visible, otherwise they are passed through to the shell as well. By default, unmodified <kbd>↑</kbd>/<kbd>↓</kbd> continue to navigate shell history; if suggestions are visible, they are hidden until you resume typing or editing the input. These can be customized in the [config](#configuration).
 
-| Action                    | Keybinding     |
-| ------------------------- | -------------- |
-| Accept Current Suggestion | <kbd>tab</kbd> |
-| View Next Suggestion      | <kbd>↓</kbd>   |
-| View Previous Suggestion  | <kbd>↑</kbd>   |
-| Dismiss Suggestions       | <kbd>esc</kbd> |
+| Action                    | Keybinding                         |
+| ------------------------- | ---------------------------------- |
+| Accept Current Suggestion | <kbd>tab</kbd>                     |
+| View Next Suggestion      | <kbd>ctrl</kbd> + <kbd>n</kbd>     |
+| View Previous Suggestion  | <kbd>ctrl</kbd> + <kbd>p</kbd>     |
+| Dismiss Suggestions       | <kbd>esc</kbd>                     |
 
 ## Integrations
 
@@ -104,15 +104,17 @@ You can customize the keybindings for inshellisense by adding a `bindings` secti
 ```toml
 [bindings.acceptSuggestion]
 key = "tab"
-# shift and ctrl are optional and default to false
+# shift and control are optional and default to false
 shift = false
-ctrl = false
+control = false
 
 [bindings.nextSuggestion]
-key = "down"
+key = "n"
+control = true
 
 [bindings.previousSuggestion]
-key = "up"
+key = "p"
+control = true
 
 [bindings.dismissSuggestions]
 key = "escape"

--- a/src/tests/ui/autocomplete.test.ts
+++ b/src/tests/ui/autocomplete.test.ts
@@ -43,12 +43,12 @@ configs.map((config) => {
       await expect(terminal.getByText("archive", { strict: false })).toHaveBgColor("7d56f4");
     });
 
-    test("cursor up when at top of list", async ({ terminal }) => {
+    test("previous suggestion when at top of list", async ({ terminal }) => {
       await expect(terminal.getByText(">  ")).toBeVisible();
       terminal.write("git ");
 
       await expect(terminal.getByText("archive", { strict: false })).toHaveBgColor("7d56f4");
-      terminal.keyUp();
+      terminal.write("\x10"); // ctrl+p
       await expect(terminal.getByText("archive", { strict: false })).toHaveBgColor("7d56f4");
     });
 
@@ -62,12 +62,12 @@ configs.map((config) => {
       await expect(terminal.getByText("archive", { strict: false })).not.toBeVisible();
     });
 
-    test("cursor down when at top of list", async ({ terminal }) => {
+    test("next suggestion when at top of list", async ({ terminal }) => {
       await expect(terminal.getByText(">  ")).toBeVisible();
       terminal.write("git ");
 
       await expect(terminal.getByText("archive", { strict: false })).toBeVisible();
-      terminal.keyDown(2);
+      terminal.write("\x0e".repeat(2)); // ctrl+n
 
       await expect(terminal.getByText("repository")).toBeVisible();
       await expect(terminal.getByText("commit")).toHaveBgColor("7d56f4");
@@ -79,7 +79,7 @@ configs.map((config) => {
       terminal.write("git ");
 
       await expect(terminal.getByText("archive", { strict: false })).toBeVisible();
-      terminal.keyDown(5);
+      terminal.write("\x0e".repeat(5)); // ctrl+n
 
       await expect(terminal.getByText("archive", { strict: false })).not.toBeVisible();
       await expect(terminal.getByText("add")).toHaveBgColor("7d56f4");
@@ -121,7 +121,7 @@ configs.map((config) => {
       terminal.write("git ");
 
       await expect(terminal.getByText("archive", { strict: false })).toBeVisible();
-      terminal.keyDown(2);
+      terminal.write("\x0e".repeat(2)); // ctrl+n
 
       await expect(terminal.getByText("repository")).toBeVisible();
       await expect(terminal.getByText("commit")).toHaveBgColor("7d56f4");

--- a/src/tests/utils/suggestionManager.test.ts
+++ b/src/tests/utils/suggestionManager.test.ts
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { SuggestionManager } from "../../ui/suggestionManager";
+import { Shell } from "../../utils/shell";
+
+class FakeTerm {
+  commandText = "g";
+  cwd = process.cwd();
+  cols = 80;
+
+  getCommandState() {
+    return { commandText: this.commandText, hasOutput: false, cursorTerminated: true };
+  }
+
+  getCursorState() {
+    return { cursorX: this.commandText.length, cursorY: 0, remainingLines: 10, hidden: false, shift: 0 };
+  }
+
+  clearCommand() {
+    return;
+  }
+
+  write() {
+    return;
+  }
+}
+
+const keyPress = (name: string, ctrl = false, sequence = name) => ({
+  name,
+  ctrl,
+  shift: false,
+  sequence,
+});
+
+describe("SuggestionManager keybindings", () => {
+  test("up and down hide suggestions and pass through for shell history", async () => {
+    const term = new FakeTerm();
+    const manager = new SuggestionManager(term as never, Shell.Bash);
+
+    await manager.exec();
+    expect(manager.render("below")).not.toHaveLength(0);
+
+    expect(manager.update(keyPress("up", false, "\x1b[A"))).toBe(false);
+    expect(manager.render("below")).toHaveLength(0);
+
+    term.commandText = "gi";
+    await manager.exec();
+    expect(manager.render("below")).toHaveLength(0);
+
+    expect(manager.update(keyPress("x"))).toBe(false);
+    term.commandText = "g";
+    await manager.exec();
+    expect(manager.render("below")).not.toHaveLength(0);
+  });
+
+  test("ctrl+n and ctrl+p navigate visible suggestions", async () => {
+    const term = new FakeTerm();
+    const manager = new SuggestionManager(term as never, Shell.Bash);
+
+    await manager.exec();
+
+    expect(manager.update(keyPress("n", true, "\x0e"))).toBe(true);
+    expect(manager.update(keyPress("p", true, "\x10"))).toBe(true);
+  });
+});

--- a/src/ui/suggestionManager.ts
+++ b/src/ui/suggestionManager.ts
@@ -54,6 +54,7 @@ export class SuggestionManager {
       this.#command = "";
     }
     if (!commandText || this.#hideSuggestions || commandState.hasOutput) {
+      this.#command = "";
       this.#suggestBlob = undefined;
       this.#activeSuggestionIdx = 0;
       return;
@@ -168,7 +169,7 @@ export class SuggestionManager {
       this.#term.clearCommand(); // clear the current command on enter
     }
 
-    // if suggestions are hidden, keep them hidden until during command navigation
+    // if suggestions are hidden, keep them hidden while navigating command history
     if (this.#hideSuggestions) {
       this.#hideSuggestions = name == "up" || name == "down";
     }
@@ -183,12 +184,22 @@ export class SuggestionManager {
       previousSuggestion: { key: prevKey, shift: prevShift, control: prevCtrl },
     } = getConfig().bindings;
 
+    const isPreviousSuggestionKey = name == prevKey && shift == !!prevShift && ctrl == !!prevCtrl;
+    const isNextSuggestionKey = name == nextKey && shift == !!nextShift && ctrl == !!nextCtrl;
+    const isShellHistoryKey = (name == "up" || name == "down") && !shift && !ctrl;
+
+    if (isShellHistoryKey && !isPreviousSuggestionKey && !isNextSuggestionKey) {
+      this.#suggestBlob = undefined;
+      this.#hideSuggestions = true;
+      return false;
+    }
+
     if (name == dismissKey && shift == !!dismissShift && ctrl == !!dismissCtrl) {
       this.#suggestBlob = undefined;
       this.#hideSuggestions = true;
-    } else if (name == prevKey && shift == !!prevShift && ctrl == !!prevCtrl) {
+    } else if (isPreviousSuggestionKey) {
       this.#activeSuggestionIdx = Math.max(0, this.#activeSuggestionIdx - 1);
-    } else if (name == nextKey && shift == !!nextShift && ctrl == !!nextCtrl) {
+    } else if (isNextSuggestionKey) {
       this.#activeSuggestionIdx = Math.min(this.#activeSuggestionIdx + 1, (this.#suggestBlob?.suggestions.length ?? 1) - 1);
     } else if (name == acceptKey && shift == !!acceptShift && ctrl == !!acceptCtrl) {
       const suggestion = this.#suggestBlob?.suggestions.at(this.#activeSuggestionIdx);

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -100,8 +100,8 @@ const configPaths = [rcPath, xdgPath];
 
 let globalConfig: Config = {
   bindings: {
-    nextSuggestion: { key: "down" },
-    previousSuggestion: { key: "up" },
+    nextSuggestion: { key: "n", control: true },
+    previousSuggestion: { key: "p", control: true },
     acceptSuggestion: { key: "tab" },
     dismissSuggestions: { key: "escape" },
   },


### PR DESCRIPTION
## Summary
- keep unmodified Up/Down passed through to the shell when suggestions are visible, hiding suggestions during history navigation
- move default suggestion navigation to Ctrl+N/Ctrl+P and update docs/tests
- add unit coverage for shell-history arrow passthrough and new suggestion navigation bindings

Fixes #418.

## Verification
- `npm test -- --runTestsByPath src/tests/utils/suggestionManager.test.ts`
- `npm run lint`
- `npm run build`
- `npm test -- --runInBand`
- `npm run test:e2e -- src/tests/ui/autocomplete.test.ts`
