### PR TITLE
fix: don't clear suggestions on direction change when nothing is rendered

### DIFF
--- a/src/tests/utils/suggestionRenderer.test.ts
+++ b/src/tests/utils/suggestionRenderer.test.ts
@@ -67,3 +67,28 @@ test("uses DEC cursor position sequences in JetBrains terminals", async () => {
     expect(data).not.toContain(ansi.cursorRestorePosition);
   });
 });
+
+test("passes data through on direction changes without visible suggestions", () => {
+  delete process.env.TERMINAL_EMULATOR;
+  const output: string[] = [];
+  const cursor = { cursorX: 0, cursorY: 20, remainingLines: 2, hidden: false, shift: 0 };
+  const term = {
+    cols: 80,
+    getCommandState: () => ({}),
+    getCursorState: () => ({ ...cursor }),
+    getPatch: () => "patch",
+    isAlternateBuffer: () => false,
+  } as unknown as ISTerm;
+  const suggestions = {
+    render: () => [],
+    suspend: async () => {},
+  } as unknown as SuggestionManager;
+  const renderer = new SuggestionRenderer(term, suggestions, (data) => output.push(data));
+
+  renderer.renderPtyData("frame-bottom", false);
+  cursor.cursorY = 2;
+  cursor.remainingLines = 20;
+  renderer.renderPtyData("frame-top", false);
+
+  expect(output).toEqual(["frame-bottom", "frame-top"]);
+});

--- a/src/ui/suggestionRenderer.ts
+++ b/src/ui/suggestionRenderer.ts
@@ -87,7 +87,8 @@ export class SuggestionRenderer {
       return;
     }
 
-    if (this.#direction !== snapshot.layout.direction) {
+    // inline redrawing apps (ink based clis, progress bars, etc.) flip the direction on every frame, so only clear when a suggestion is rendered
+    if (this.#visible && this.#direction !== snapshot.layout.direction) {
       this.#clearPreviousDirection(snapshot);
     }
     this.#render(data, preserveDuringBackspaceEcho, snapshot);


### PR DESCRIPTION
main already suspends suggestions while the alternate buffer is active, but apps that redraw inline on the normal buffer (claude code, codex, other ink based clis) are still broken: every cursor jump flips the suggestion layout direction and triggers a clear even when no suggestion is rendered, overdrawing the app's output on every frame. This gates the direction change clear on visible suggestions so those apps get pure passthrough.

Closes #411