### PR TITLE
fix: honor Nerd Font icons for top-level commands

### DIFF
--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -9,7 +9,7 @@ import figSpecList, {
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { parseCommand, CommandToken } from "./parser.js";
-import { getArgDrivenRecommendation, getSubcommandDrivenRecommendation, SuggestionIcons } from "./suggestion.js";
+import { getArgDrivenRecommendation, getIcon, getSubcommandDrivenRecommendation } from "./suggestion.js";
 import { Suggestion, SuggestionBlob } from "./model.js";
 import { buildExecuteShellCommand, resolveCwd } from "./utils.js";
 import { Shell } from "../utils/shell.js";
@@ -445,7 +445,7 @@ const runCommand = async (token: CommandToken): Promise<SuggestionBlob | undefin
             name: alias,
             type: "shortcut",
             allNames: [alias],
-            icon: SuggestionIcons.Shortcut,
+            icon: getIcon(`fig://icon?type=${alias}`, "shortcut"),
             priority: 100,
           }) as Suggestion,
       ),
@@ -455,7 +455,7 @@ const runCommand = async (token: CommandToken): Promise<SuggestionBlob | undefin
             name: spec,
             type: "subcommand",
             allNames: [spec],
-            icon: SuggestionIcons.Subcommand,
+            icon: getIcon(`fig://icon?type=${spec}`, "subcommand"),
             priority: 40,
           }) as Suggestion,
       ),

--- a/src/runtime/suggestion.ts
+++ b/src/runtime/suggestion.ts
@@ -60,7 +60,7 @@ export const NerdFontIcons = {
   yarn: "\ue8ec",
 };
 
-const getIcon = (icon: string | undefined, suggestionType: Fig.SuggestionType | undefined): string => {
+export const getIcon = (icon: string | undefined, suggestionType: Fig.SuggestionType | undefined): string => {
   // eslint-disable-next-line no-control-regex
   if (icon && /[^\u0000-\u00ff]/.test(icon)) {
     return icon;

--- a/src/tests/runtime/runtime.test.ts
+++ b/src/tests/runtime/runtime.test.ts
@@ -5,8 +5,9 @@ import fs from "node:fs";
 
 import { getSuggestions } from "../../runtime/runtime.js";
 import { Shell } from "../../utils/shell.js";
-import { SuggestionIcons } from "../../runtime/suggestion.js";
+import { NerdFontIcons, SuggestionIcons } from "../../runtime/suggestion.js";
 import { unpackResources } from "../../utils/node.js";
+import { getConfig } from "../../utils/config.js";
 
 const testData = [
   { name: "partialPrefixFilter", command: "git sta" },
@@ -112,4 +113,17 @@ describe(`getCommandSuggestions`, () => {
       expect(icons).toEqual(expect.arrayContaining(expectedIcons ?? []));
     });
   });
+});
+
+test("top-level commands use Nerd Font icons when enabled", async () => {
+  const config = getConfig();
+  const previous = config.useNerdFont;
+  config.useNerdFont = true;
+  try {
+    const suggestions = await getSuggestions("git", process.cwd(), Shell.Bash);
+    const git = suggestions?.suggestions.find((suggestion) => suggestion.name === "git");
+    expect(git?.icon).toBe(NerdFontIcons.git);
+  } finally {
+    config.useNerdFont = previous;
+  }
 });


### PR DESCRIPTION
## What & why

Fixes #437. The top-level command path built suggestions with hard-coded
`SuggestionIcons` values, so `useNerdFont=true` only affected nested suggestions.
Route those command and alias icons through the existing icon resolver so known
top-level commands (for example `git`) use their Nerd Font glyph while unknown
commands retain the existing fallback icon.

## Evidence

- Added a regression that enables the real config object and asserts the `git`
  top-level suggestion uses `NerdFontIcons.git`.
- `npm test -- --runInBand src/tests/runtime/runtime.test.ts -t "top-level commands use Nerd Font icons when enabled"` (1 passed)
- `npm run build` (passed)
- `npm run lint` (passed; only the repository's existing React autodetect warning)
- `git diff --check` (passed)

The broader runtime test file still has one pre-existing environment failure in
the unrelated `pre-commit` generator fixture (`/Users/saksham/.inshellisense`);
all 21 snapshots and the changed behavior's focused regression pass.

## Checklist

- [x] Focused regression added and run
- [x] Build and lint pass
- [x] Commit is DCO signed off
